### PR TITLE
feat: change global style settings to styled component createGlobalStyle

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RecoilRoot } from 'recoil';
+import GlobalStyle from './styles/global-styles';
 import Root from './pages/Root';
 import Main from './pages/Main';
 import Member from './pages/Member';
@@ -66,6 +67,7 @@ function App() {
   return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
+        <GlobalStyle />
         <RouterProvider router={router} />
       </QueryClientProvider>
     </RecoilRoot>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,29 +10,6 @@
   font-style: normal;
 }
 
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  max-width: 100%;
-}
-
-body {
-  font-family: 'inter', sans-serif;
-  background-color: var(--color-bg-100);
-  width: 100vw;
-  height: 100vh;
-}
-
-a {
-  text-decoration: none;
-}
-
-input:focus {
-  outline: none;
-}
-
 .lds-ellipsis {
   display: inline-block;
   position: relative;
@@ -87,10 +64,4 @@ input:focus {
   100% {
     transform: translate(10px, 0);
   }
-}
-
-button {
-  all: unset;
-  cursor: pointer;
-  text-align: center;
 }

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -4,6 +4,7 @@ const Main = () => {
   return (
     <>
       <Carousel />
+      <h1>안녕하세요</h1>
     </>
   );
 };

--- a/client/src/pages/Root.tsx
+++ b/client/src/pages/Root.tsx
@@ -1,12 +1,10 @@
 import { Outlet } from 'react-router-dom';
 import Header from '../components/header/Header';
 import { S_Root, S_Wrapper, S_Container } from '../style/style';
-import useMediaQuery from '../hooks/useMediaQuery';
 
 function Root() {
-  const isMobile = useMediaQuery('(max-width: 480px)');
   return (
-    <S_Root $isMobile={isMobile}>
+    <S_Root>
       <Header />
       <S_Wrapper>
         <S_Container>

--- a/client/src/style/style.ts
+++ b/client/src/style/style.ts
@@ -10,6 +10,17 @@ export const S_Root = styled.div`
   @media only screen and (max-width: 480px) {
     font-size: 13px;
   }
+  & h1,
+  h2,
+  h3,
+  h4 {
+    font-size: 18px;
+    color: white;
+    @media only screen and (max-width: 480px) {
+      font-size: 14px;
+      color: white;
+    }
+  }
 `;
 
 /* ----- Wrapper Root-Main ----- */

--- a/client/src/style/style.ts
+++ b/client/src/style/style.ts
@@ -15,10 +15,8 @@ export const S_Root = styled.div`
   h3,
   h4 {
     font-size: 18px;
-    color: white;
     @media only screen and (max-width: 480px) {
       font-size: 14px;
-      color: white;
     }
   }
 `;

--- a/client/src/styles/global-styles.ts
+++ b/client/src/styles/global-styles.ts
@@ -1,0 +1,41 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  max-width: 100%;
+}
+
+body {
+  font-family: 'inter', sans-serif;
+  background-color: var(--color-bg-100);
+  width: 100vw;
+  height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+input, button {
+  all: unset;
+  cursor: pointer;
+  text-align: center;
+  border: none;
+  outline: none;
+}
+
+input:focus {
+  outline: none;
+}
+
+ol, ul, li {
+  list-style: none;
+}
+`;
+
+export default GlobalStyle;

--- a/client/src/styles/style.ts
+++ b/client/src/styles/style.ts
@@ -6,10 +6,6 @@ export const S_Root = styled.div`
   height: 100vh;
   display: flex;
   flex-direction: column;
-  font-size: 16px;
-  @media only screen and (max-width: 480px) {
-    font-size: 13px;
-  }
 `;
 
 /* ----- Wrapper Root-Main ----- */


### PR DESCRIPTION
- index.css의 전역 스타일 설정을 styled-component의 createGlobalStyle로 옮겼습니다.
- 윈도우 크기에 따라 폰트 사이즈 변경하는 로직을 prop을 받아 처리해 주던 것에서 미디어쿼리를 활용하는 방식으로 바꿨습니다.
- heading 요소들의 기본 폰트사이즈를 데스크탑뷰에서는 18px, 모바일뷰에서는 14px로 설정했습니다.