### PR TITLE
feat/moviepage: Movie 페이지(배너, 장르별리스트) 구현

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -35,3 +35,7 @@ export const DeleteUser = () => instance.delete('/members');
 /* TV 데이터 가져오기 */
 export const GetTVData = (): Promise<ItemData[]> =>
   instance.get('/TV').then((res) => res.data);
+
+/* Movie 데이터 가져오기 */
+export const GetMovieData = (): Promise<ItemData[]> =>
+  instance.get('/movie').then((res) => res.data);

--- a/client/src/components/silde/SildeMovie.tsx
+++ b/client/src/components/silde/SildeMovie.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from 'react';
+import { GetMovieData } from '../../api/api';
+import { ItemData } from '../../types/types';
+import Item from '../ui/ItemCard';
+import styled from 'styled-components';
+import SwiperCore, { Virtual, Navigation } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/navigation';
+
+// install Virtual module
+SwiperCore.use([Virtual, Navigation]);
+
+const SildeMovie = () => {
+  const [, setSwiperRef] = useState<SwiperCore | null>(null);
+  const genres: string[] = [
+    '드라마',
+    '액션',
+    '로맨스',
+    '애니',
+    '코미디',
+    '판타지',
+    '스릴러',
+    '호러',
+    '음악',
+    '사극',
+    '다큐멘터리',
+    '스포츠'
+  ];
+  const [movieData, setMovieData] = useState<ItemData[][]>([]); // Movie 데이터를 저장할 상태
+  useEffect(() => {
+    Promise.all(
+      genres.map((genre) => {
+        return GetMovieData()
+          .then((data) => {
+            const filteredData = data.filter((movie) => movie.genre.includes(genre));
+            return filteredData;
+          })
+          .catch((error) => {
+            console.error(`'${genre}' 장르의 Movie 데이터 가져오기 실패:`, error);
+            return [];
+          });
+      })
+    )
+      .then((results) => {
+        setMovieData(results);
+      })
+      .catch((error) => {
+        console.error('Movie 데이터 가져오기 실패:', error);
+        setMovieData([]);
+      });
+  }, []);
+
+  return (
+    <S_Wrapper>
+      {genres.map((genre, index) => (
+        <S_Genrelist key={index}>
+          <S_GenreTitle>{genre}</S_GenreTitle>
+          {movieData[index] ? (
+            <S_Swiper
+              onSwiper={setSwiperRef}
+              slidesPerView={6} // 한 슬라이드에 보여줄 갯수
+              centeredSlides={false} // 센터 모드
+              spaceBetween={18} // 슬라이드 사이 여백
+              navigation={true} // 버튼
+              watchOverflow={true}
+              virtual
+            >
+              {movieData[index].map((data: ItemData, slideIndex: number) => (
+                <S_SwiperSlide key={data.id} virtualIndex={slideIndex}>
+                  <Item data={data} />
+                </S_SwiperSlide>
+              ))}
+            </S_Swiper>
+          ) : (
+            <S_LoadingMessage>Loading Movie data...</S_LoadingMessage>
+          )}
+        </S_Genrelist>
+      ))}
+    </S_Wrapper>
+  );
+};
+
+export default SildeMovie;
+
+const S_Wrapper = styled.div`
+  position: relative;
+  overflow-x: hidden; // 가로 스크롤 숨김
+  margin: 0;
+  padding: 0px 3.75rem;
+  width: 100%;
+`;
+
+const S_Genrelist = styled.div`
+  margin-bottom: 3.75rem;
+`;
+
+const S_GenreTitle = styled.h2`
+  margin: 28px 0 10px 0;
+  color: var(--color-white-100);
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+const S_Swiper = styled(Swiper)`
+  display: flex;
+  overflow: visible; // 요소의 내용이 요소의 크기를 넘어갈 경우에도 내용을 표시
+  margin: 20px auto;
+
+  .swiper-button-prev,
+  .swiper-button-next {
+    top: 50%;
+    margin: 0;
+    padding: 1.5rem;
+    height: 100%;
+    transform: translateY(-50%);
+    background-repeat: no-repeat;
+    background: var(--color-bg-60);
+    color: var(--color-white-100);
+    text-shadow: 4px 4px 10px rgba(0, 0, 0, 0.4);
+    z-index: 10;
+    --swiper-navigation-size: 2.5rem;
+    opacity: 0;
+  }
+  .swiper-button-prev {
+    left: -3.75rem;
+  }
+  .swiper-button-next {
+    right: -3.75rem;
+  }
+
+  &:hover {
+    .swiper-button-prev,
+    .swiper-button-next {
+      opacity: 1;
+      transition: opacity 0.3s ease;
+    }
+  } 
+`
+
+const S_SwiperSlide = styled(SwiperSlide)`
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease;
+  filter: var(--shadow-l-40);
+  cursor: pointer;
+  &:hover {
+    transform: translateY(-15px);
+  }
+`;
+
+const S_LoadingMessage = styled.div`
+  color: var(--color-white-80);
+`;

--- a/client/src/components/silde/SildeTV.tsx
+++ b/client/src/components/silde/SildeTV.tsx
@@ -11,7 +11,7 @@ import 'swiper/css/navigation';
 // install Virtual module
 SwiperCore.use([Virtual, Navigation]);
 
-const Silde = () => {
+const SildeTV = () => {
   const [, setSwiperRef] = useState<SwiperCore | null>(null);
   const genres: string[] = [
     '드라마',
@@ -81,7 +81,7 @@ const Silde = () => {
   );
 };
 
-export default Silde;
+export default SildeTV;
 
 const S_Wrapper = styled.div`
   position: relative;

--- a/client/src/pages/Movie.tsx
+++ b/client/src/pages/Movie.tsx
@@ -1,5 +1,22 @@
+import Banner from '../components/banner/Banner';
+import SildeMovie from '../components/silde/SildeMovie';
+import image from '../assets/기적의형제.webp'
+import styled from 'styled-components';
+
 const Movie = () => {
-  return <div></div>;
+  return (
+    <S_Wrapper>
+      <Banner image={image}/>
+      <SildeMovie/>
+    </S_Wrapper>
+  );
 };
 
 export default Movie;
+
+const S_Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100vw;
+`;

--- a/client/src/pages/TV.tsx
+++ b/client/src/pages/TV.tsx
@@ -1,5 +1,5 @@
 import Banner from '../components/banner/Banner';
-import Silde from '../components/silde/Silde';
+import SildeTV from '../components/silde/SildeTV';
 import image from '../assets/이번생도잘부탁해.webp'
 import styled from 'styled-components';
 
@@ -7,7 +7,7 @@ const TV = () => {
   return (
     <S_Wrapper>
       <Banner image={image}/>
-      <Silde/>
+      <SildeTV/>
     </S_Wrapper>
   );
 };


### PR DESCRIPTION
## 추가 사항
- [x] UI 구현
- [x]  Movie 메인 추천 배너 띄우기
  - 배너 하단에 검정색 그라디언트 처리
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/54f3ba6e-d4d4-4545-b086-bdcc88fcf8d5)

<br>

- [x] 영화 장르별 슬라이더 구현
  - hover 시 컨텐츠가 위로 올라오며, 좌우에 화살표 버튼이 생긴다.
  - 장르별(ex - 드라마, 코미디 ...)로 필터링이 되어 화면에 뿌려진다.
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/6725c8f4-d4a1-4155-96c6-0859f2446b65)

<br>

## 변경 사항
- silde 파일을 sildeTV로 변경, sildeMovie 추가
* 영화 더미데이터 일부 추가