### PR TITLE
:sparkles: Feat/skeleton: 로딩중 스켈레톤 ui 구현

### DIFF
--- a/client/src/components/silde/SildeMovie.tsx
+++ b/client/src/components/silde/SildeMovie.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { GetMovieData } from '../../api/api';
 import ItemCard from '../ui/ItemCard';
+import SkeletonItemCard from '../ui/SkeletonItemCard';
 import styled from 'styled-components';
 import SwiperCore, { Virtual, Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
-import { useQuery } from '@tanstack/react-query';
 
 // install Virtual module
 SwiperCore.use([Virtual, Navigation]);
@@ -19,7 +20,17 @@ const SildeMovie = ({ genre }: { genre: string }) => {
     queryFn: () => GetMovieData(genre),
   });
 
-  if (isLoading) return 'Loading...';
+  if (isLoading) {
+    return (
+      <S_Wrapper>
+        <S_SkeletonBox>
+        {Array.from({ length: 6 }, (_, index) => (
+          <SkeletonItemCard  key={index}/>
+        ))}
+        </S_SkeletonBox>
+      </S_Wrapper>
+    );
+  }
 
   if (error instanceof Error) return 'An error has occurred: ' + error.message;
 
@@ -99,6 +110,8 @@ const S_SwiperSlide = styled(SwiperSlide)`
   cursor: pointer;
 `;
 
-// const S_LoadingMessage = styled.div`
-//   color: var(--color-white-80);
-// `;
+const S_SkeletonBox = styled.div`
+  display: flex;
+  gap: 18px;
+  margin-bottom: 3.75rem;
+`;

--- a/client/src/components/silde/SildeTV.tsx
+++ b/client/src/components/silde/SildeTV.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query'
 import { GetTVData } from '../../api/api';
 import ItemCard from '../ui/ItemCard';
+import SkeletonItemCard from '../ui/SkeletonItemCard';
 import styled from 'styled-components';
 import SwiperCore, { Virtual, Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
-import { useQuery } from '@tanstack/react-query'
 
 // install Virtual module
 SwiperCore.use([Virtual, Navigation]);
@@ -19,7 +20,17 @@ const SildeTV = ({genre}: {genre: string}) => {
     queryFn: () => GetTVData(genre),
   })
 
-  if (isLoading) return 'Loading...'
+  if (isLoading) {
+    return (
+      <S_Wrapper>
+        <S_SkeletonBox>
+        {Array.from({ length: 6 }, (_, index) => (
+          <SkeletonItemCard  key={index}/>
+        ))}
+        </S_SkeletonBox>
+      </S_Wrapper>
+    );
+  }
 
   if (error instanceof Error) return 'An error has occurred: ' + error.message
 
@@ -56,17 +67,6 @@ const S_Wrapper = styled.div`
   padding: 0px 3.75rem;
   width: 100%;
 `;
-
-// const S_Genrelist = styled.div`
-//   margin-bottom: 3.75rem;
-// `;
-
-// const S_GenreTitle = styled.h2`
-//   margin: 28px 0 10px 0;
-//   color: var(--color-white-100);
-//   font-size: 24px;
-//   font-weight: 700;
-// `;
 
 const S_Swiper = styled(Swiper)`
   display: flex;
@@ -110,6 +110,8 @@ const S_SwiperSlide = styled(SwiperSlide)`
   cursor: pointer;
 `;
 
-// const S_LoadingMessage = styled.div`
-//   color: var(--color-white-80);
-// `;
+const S_SkeletonBox = styled.div`
+  display: flex;
+  gap: 18px;
+  margin-bottom: 3.75rem;
+`;

--- a/client/src/components/ui/SkeletonItemCard.tsx
+++ b/client/src/components/ui/SkeletonItemCard.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+const SkeletonItemCard = () => {
+  return (
+    <>
+      <S_ItemBox>
+        <S_ItemImage />
+        <S_ItemTitle />
+      </S_ItemBox>
+    </>
+  );
+};
+
+export default SkeletonItemCard;
+
+const S_ItemBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const S_ItemImage = styled.div`
+  padding-top: calc(4.2 / 3 * 100%);
+  aspect-ratio: 3/4.2;
+  border-radius: 10px;
+  background-color: var(--color-dropdown);
+`;
+
+const S_ItemTitle = styled.div`
+  margin-top: 10px;
+  height: 18px;
+  border-radius: 5px;
+  background-color: var(--color-dropdown);
+`;


### PR DESCRIPTION
## 구현 사항
- [x] 데이터를 조회 시 로딩중일 때 스켈레톤 화면을 띄워줌

  ![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/9ba09633-7c84-490f-a225-bb9e6718a761)
  - length의 개수에 따라 보여지는 skeleton card의 수가 달라짐 (SildeTV.tsx, SildeMovie.tsx)
    ```ts
      if (isLoading) {
        return (
          <S_Wrapper>
            <S_SkeletonBox>
            {Array.from({ length: 6 }, (_, index) => (
              <SkeletonItemCard  key={index}/>
            ))}
            </S_SkeletonBox>
          </S_Wrapper>
        );
      }
    ```