### PR TITLE
feat: close user nickname input after patching data

### DIFF
--- a/client/src/components/member/MemberInfo/Information.tsx
+++ b/client/src/components/member/MemberInfo/Information.tsx
@@ -26,6 +26,7 @@ function Information() {
       ...data,
       nickname: userInput,
     });
+    setIsEditing(false);
   };
   const { isLoading, data, error, isSuccess } = useQuery({
     queryKey: ['user'],


### PR DESCRIPTION
### PR에 관한 간략한 설명
유저 닉네임 변경 직후에 인풋창이 닫히고 바뀐 닉네임이 보이게 수정했습니다.

### 기능 구현 및 수정 세부 사항
- [x] 닉네임 변경 후에 인풋창이 닫히도록 함


### 수정 사항 확인 방법
