### PR TITLE
feat: 검색기능, 갯수합추가, 서치바 수정

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -67,7 +67,7 @@ export const GetDataDetail = (mediaId: string): Promise<SelectedData> =>
 /* 검색결과 가져오기 */
 export const GetSearchedData = (keyword: string | null) =>
   axios
-    .get(`${import.meta.env.VITE_BASE_URL}/search?keyword=${keyword}`)
+    .get(`${import.meta.env.VITE_BASE_URL}/search?q=${keyword}`)
     .then((res) => res.data);
 
 /* 후기 데이터 */

--- a/client/src/components/carousel/Carousel.tsx
+++ b/client/src/components/carousel/Carousel.tsx
@@ -114,7 +114,7 @@ export default function Carousel() {
 
 const S_Wrapper = styled.div`
   margin-top: 130px;
-  width: 100%;
+  width: 100vw;
   height: 450px;
   background-color: var(--color-bg-100);
   background-position: center;

--- a/client/src/components/header/SearchBar.tsx
+++ b/client/src/components/header/SearchBar.tsx
@@ -31,6 +31,7 @@ function SearchBar() {
       <S_Input
         $show={showSearchBar}
         type="text"
+        value={userInput}
         onChange={handleChange}
         onKeyUp={handleKeyUp}
       />

--- a/client/src/components/slide/InfinityScroll.tsx
+++ b/client/src/components/slide/InfinityScroll.tsx
@@ -16,14 +16,12 @@ const InfinityScroll = ({ path, query }: { path: string; query: string }) => {
   if (path.includes('movie')) {
     category = '/movie';
   }
-
+  console.log(query);
   const { data, fetchNextPage, hasNextPage, status } = useInfiniteQuery(
     path.includes('search') ? ['search', query] : ['selectedList', query],
     ({ pageParam = 1 }) =>
       path.includes('search')
-        ? GetSearchedData(
-            `/medias/search?page=${pageParam}&size=24&keyword=${query}`
-          )
+        ? GetSearchedData(`${query}&page=${pageParam}&size=24`)
         : GetFilterdData(
             `/medias${category}?page=${pageParam}&size=24&${query}`
           ),
@@ -67,10 +65,16 @@ const InfinityScroll = ({ path, query }: { path: string; query: string }) => {
   if (status === 'error') return <S_Error>검색 결과 없음</S_Error>;
 
   if (status === 'success') {
+    const totalLength = (data?.pages || []).reduce(
+      (acc, page) => acc + (page.content?.length || 0),
+      0
+    );
     return (
       <>
         {path.includes('search') && (
-          <S_Text>'{path}' 검색 결과가 ??개 있습니다.</S_Text>
+          <S_Text>
+            '{query}' 검색 결과가 {totalLength}개 있습니다.
+          </S_Text>
         )}
         <S_FlexWrap>
           {data.pages.map((page) => (
@@ -92,6 +96,7 @@ const InfinityScroll = ({ path, query }: { path: string; query: string }) => {
 export default InfinityScroll;
 
 const S_FlexWrap = styled.div`
+  width: 100vw;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -1,8 +1,17 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import InfinityScroll from '../components/slide/InfinityScroll';
 
 const Search = () => {
-  const keyword = new URLSearchParams(location.search).get('keyword') as string;
+  const [keyword, setKeyword] = useState('');
+  const location = useLocation();
+
+  useEffect(() => {
+    const newKeyword =
+      new URLSearchParams(location.search).get('keyword') || '';
+    setKeyword(newKeyword);
+  }, [location.search]);
 
   return (
     <S_Wrapper>


### PR DESCRIPTION
헤더에서 검색시 인풋이 초기화되지 않아서 value를 추가해주었습니다.
검색마다 재렌더링이 이루어지고 List 페이지와 동일하게 24개 무한스크롤 기능입니다.
총합갯수가 렌더링됩니다.