### PR TITLE
:construction: Feat/recommendcontent: 컨텐츠 추천 컴포넌트 구현중

### DIFF
--- a/client/src/components/contents/RecommendContent.tsx
+++ b/client/src/components/contents/RecommendContent.tsx
@@ -1,0 +1,83 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetTVData } from '../../api/api';
+import styled from 'styled-components';
+import ItemCard from '../ui/ItemCard';
+import SkeletonItemCard from '../ui/SkeletonItemCard';
+import { ContentData } from '../../types/types';
+
+const RecommendContent = ({ genre }: { genre: string }) => {
+
+  const { isLoading, error, data, isSuccess } = useQuery({
+    queryKey: ['tvData', genre],
+    queryFn: () => GetTVData(genre),
+  });
+
+  if (isLoading) {
+    return (
+      <>
+        <S_Text>
+        이런 컨텐츠는 어떠세요?
+        </S_Text>
+        <S_Wrapper>
+          <S_SkeletonBox>
+          {Array.from({ length: 6 }, (_, index) => (
+            <S_Item key={index}>
+              <SkeletonItemCard />
+            </S_Item>
+          ))}
+          </S_SkeletonBox>
+        </S_Wrapper>
+      </>
+    );
+  }
+
+  if (error instanceof Error) return 'An error has occurred: ' + error.message;
+
+  if (isSuccess) {
+    const itemsToShow = data.content.slice(0, 6);
+
+    return (
+      <>
+        <S_Text>
+        이런 컨텐츠는 어떠세요?
+        </S_Text>
+        <S_Wrapper>
+          {itemsToShow.map((item: ContentData) => (
+            <S_Item>
+              <ItemCard item={item} />
+            </S_Item>
+          ))}
+        </S_Wrapper>
+      </>
+    );
+  }
+};
+
+export default RecommendContent;
+
+const S_Wrapper = styled.div`
+  display: flex;
+  /* flex-wrap: wrap; */
+  width: 100vw;
+  /* justify-content: space-between; */
+  padding: 0px 30px;
+`;
+
+const S_Text = styled.p`
+  margin: 28px 0 10px 0;
+  padding: 0px 30px;
+  color: var(--color-white-100);
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+const S_Item = styled.div`
+  width: 225px;
+  margin: 0 7.5px 50px;
+`;
+
+const S_SkeletonBox = styled.div`
+  display: flex;
+  /* gap: 18px; */
+  margin-bottom: 3.75rem;
+`;

--- a/client/src/pages/Content.tsx
+++ b/client/src/pages/Content.tsx
@@ -1,15 +1,20 @@
 import { useParams } from 'react-router-dom';
 import ContentDetail from '../components/contents/ContentDetail';
 import CommentSection from '../components/comments/CommentSection';
+import RecommendContent from '../components/contents/RecommendContent';
 import { scrollToTop } from '../utils/scrollToTop';
 
 const Content = () => {
   const { id = '' } = useParams<{ id?: string }>();
   scrollToTop();
+
+  const genre: string = '판타지'
+
   return (
     <>
       <ContentDetail contentId={id} />
       <CommentSection />
+      <RecommendContent genre={genre}/>
     </>
   );
 };


### PR DESCRIPTION
## 변경 사항
- 미디어 상세조회 페이지 하단에 있는 컨텐츠 컴포넌트 틀 구현
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/04c416c5-53dc-41c9-aba8-df46a26f4b58)

<br>

## 이슈 사항
- 현재 데이터에 title이 비워져 있는 경우가 다수 발견됨.
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/4114ea59-f6d2-4c62-8e55-2540ce967808)

<br>

## 추가해야할 사항
- 상세 조회된 컨텐츠와 같은 카테고리와 장르가 추천 컨텐츠로 뜨도록 수정해야 함.
