### PR TITLE
Feat/admin 관리자 미디어 추가, 삭제 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "match-sorter": "^6.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.45.1",
         "react-icons": "^4.10.1",
         "react-intersection-observer": "^9.5.2",
         "react-router-dom": "^6.14.0",
@@ -6569,6 +6570,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.45.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.1.tgz",
+      "integrity": "sha512-6dWoFJwycbuFfw/iKMcl+RdAOAOHDiF11KWYhNDRN/OkUt+Di5qsZHwA0OwsVnu9y135gkHpTw9DJA+WzCeR9w==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-icons": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "match-sorter": "^6.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.1",
     "react-icons": "^4.10.1",
     "react-intersection-observer": "^9.5.2",
     "react-router-dom": "^6.14.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import Content from './pages/Content';
 import Search from './pages/Search';
 import List from './pages/List';
 import Recommend from './pages/Recommend';
+import Admin from './pages/Admin';
 import './App.css';
 
 const router = createBrowserRouter([
@@ -66,6 +67,10 @@ const router = createBrowserRouter([
       {
         path: 'recommend',
         element: <Recommend />,
+      },
+      {
+        path: 'admin',
+        element: <Admin />,
       },
     ],
   },

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -68,7 +68,7 @@ export const GetDataDetail = (mediaId: string): Promise<SelectedData> =>
     .then((res) => res.data);
 
 /* 검색결과 가져오기 */
-export const GetSearchedData = (keyword: string | null) =>
+export const GetSearchedData = (keyword: string) =>
   axios
     .get(`${import.meta.env.VITE_BASE_URL}/search?q=${keyword}`)
     .then((res) => res.data);
@@ -111,25 +111,25 @@ export const PatchComment = ({
 }) => instance.patch(`/reviews/${id}`, { content: content });
 
 /* 리스트 필터 가져오기 */
-export const GetFilterdData = (queryString: string | null): Promise<ItemData> =>
+export const GetFilterdData = (queryString: string): Promise<ItemData> =>
   axios
     .get(`${import.meta.env.VITE_BASE_URL}${queryString}`)
     .then((res) => res.data);
 
 /* 북마크 조회 */
-export const GetIsBookmark = (mediaId: string | null) =>
+export const GetIsBookmark = (mediaId: string) =>
   instance.get(`/bookmarks/${mediaId}`).then((res) => res.data);
 
 /* 북마크 생성/삭제 */
-export const PostBookmark = (mediaId: string | null) =>
+export const PostBookmark = (mediaId: string) =>
   instance.post(`/bookmarks`, { mediaId });
 
 /* 추천 조회 */
-export const GetIsRecommend = (mediaId: string | null) =>
+export const GetIsRecommend = (mediaId: string) =>
   instance.get(`/recommend/${mediaId}`).then((res) => res.data);
 
 /* 추천 생성/삭제 */
-export const PostRecommend = (mediaId: string | null) =>
+export const PostRecommend = (mediaId: string) =>
   instance.post(`/recommend`, { mediaId });
 
 /* 유저 찜, 좋아요 조회 */
@@ -152,3 +152,7 @@ export const PostUserProfile = (data: FormData) =>
 /* 관리자 미디어 생성 */
 export const AdminPostData = (mediaData: AddData) =>
   instance.post(`/medias`, mediaData);
+
+/* 관리자 미디어 제거 */
+export const AdminDeleteData = (mediaId: string) =>
+  instance.delete(`/medias/${mediaId}`);

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -5,6 +5,7 @@ import {
   ItemData,
   CommentData,
   SelectedData,
+  AddData,
   ContentData,
   Comment,
 } from '../types/types';
@@ -147,3 +148,7 @@ export const PostUserProfile = (data: FormData) =>
       'Content-Type': 'multipart/form-data',
     },
   });
+
+/* 관리자 미디어 생성 */
+export const AdminPostData = (mediaData: AddData) =>
+  instance.post(`/medias`, mediaData);

--- a/client/src/components/admin/AddMedia.tsx
+++ b/client/src/components/admin/AddMedia.tsx
@@ -123,10 +123,20 @@ const AddMedia = () => {
       <input id="recent" type="checkbox" value="true" {...register('recent')} />
 
       <label htmlFor="genre">장르</label>
-      <input id="genre" type="text" {...register('genre')} />
+      <input
+        id="genre"
+        type="text"
+        placeholder="액션,드라마,SF,스릴러,애니메이션,코미디,가족,판타지..."
+        {...register('genre')}
+      />
 
       <label htmlFor="ottName">OTT 이름</label>
-      <input id="ottName" type="text" {...register('ottName')} />
+      <input
+        id="ottName"
+        type="text"
+        placeholder="Netflix,Disney Plus,Watcha,wavve,Tving"
+        {...register('ottName')}
+      />
 
       <label htmlFor="ottAddress">OTT 주소</label>
       <input id="ottAddress" type="text" {...register('ottAddress')} />

--- a/client/src/components/admin/AddMedia.tsx
+++ b/client/src/components/admin/AddMedia.tsx
@@ -1,0 +1,175 @@
+import { useMutation } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import styled from 'styled-components';
+import { AdminPostData } from '../../api/api';
+import { AddData } from '../../types/types';
+
+const AddMedia = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm();
+
+  const AddMediaMutation = useMutation({
+    mutationFn: (convertedData: AddData) => AdminPostData(convertedData),
+    onSuccess: () => {
+      alert('등록 완료');
+    },
+    onError(error) {
+      console.error(error);
+    },
+  });
+
+  const convertData = (data: Record<string, any>) => {
+    const convertedData: AddData = {
+      title: data.title,
+      content: data.content,
+      category: data.category,
+      creator: data.creator,
+      cast: data.cast,
+      mainPoster: data.mainPoster,
+      titlePoster: data.titlePoster,
+      releaseDate: parseInt(data.releaseDate),
+      ageRate: data.ageRate,
+      recent: data.recent === 'true',
+      genre: data.genre.split(',').map((item: string) => item.trim()),
+      mediaOtt: [
+        {
+          ottName: data.ottName,
+          ottAddress: data.ottAddress,
+        },
+      ],
+    };
+    return convertedData;
+  };
+
+  return (
+    <S_Form
+      onSubmit={handleSubmit(async (data) => {
+        await new Promise((r) => setTimeout(r, 1000));
+        const convertedData = convertData(data);
+        AddMediaMutation.mutate(convertedData);
+      })}
+    >
+      <label htmlFor="title">제목</label>
+      <input
+        id="title"
+        type="text"
+        placeholder="string"
+        {...register('title')}
+      />
+
+      <label htmlFor="content">내용</label>
+      <input
+        id="content"
+        type="text"
+        placeholder="string"
+        {...register('content')}
+      />
+
+      <label htmlFor="category">카테고리</label>
+      <input
+        id="category"
+        type="text"
+        placeholder="TV || 영화 string"
+        {...register('category')}
+      />
+
+      <label htmlFor="creator">제작자</label>
+      <input
+        id="creator"
+        type="text"
+        placeholder="제작자 X"
+        {...register('creator')}
+      />
+
+      <label htmlFor="cast">출연진</label>
+      <input id="cast" type="text" placeholder="string" {...register('cast')} />
+
+      <label htmlFor="mainPoster">메인 포스터</label>
+      <input
+        id="mainPoster"
+        type="text"
+        placeholder="string"
+        {...register('mainPoster')}
+      />
+
+      <label htmlFor="titlePoster">타이틀 포스터</label>
+      <input
+        id="titlePoster"
+        type="text"
+        placeholder="string"
+        {...register('titlePoster')}
+      />
+
+      <label htmlFor="releaseDate">개봉일</label>
+      <input
+        id="releaseDate"
+        type="number"
+        placeholder="4자리 number"
+        {...register('releaseDate')}
+      />
+
+      <label htmlFor="ageRate">연령 등급</label>
+      <input
+        id="ageRate"
+        type="text"
+        placeholder="연령 X"
+        {...register('ageRate')}
+      />
+
+      <label htmlFor="recent">최신 여부</label>
+      <input id="recent" type="checkbox" value="true" {...register('recent')} />
+
+      <label htmlFor="genre">장르</label>
+      <input id="genre" type="text" {...register('genre')} />
+
+      <label htmlFor="ottName">OTT 이름</label>
+      <input id="ottName" type="text" {...register('ottName')} />
+
+      <label htmlFor="ottAddress">OTT 주소</label>
+      <input id="ottAddress" type="text" {...register('ottAddress')} />
+
+      {/* 이메일과 비밀번호 제거를 위한 주석 */}
+      {/* <label htmlFor="email">이메일</label>
+      <input id="email" type="email" {...register('email')} />
+
+      <label htmlFor="password">비밀번호</label>
+      <input id="password" type="password" {...register('password')} /> */}
+
+      <button type="submit" disabled={isSubmitting}>
+        미디어 생성
+      </button>
+    </S_Form>
+  );
+};
+
+export default AddMedia;
+
+const S_Form = styled.form`
+  width: 500px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid white;
+  padding: 10px;
+  margin: 0 20px;
+
+  label {
+    color: white;
+    margin-top: 10px;
+  }
+
+  input {
+    color: black;
+    font-size: 18px;
+    height: 30px;
+  }
+
+  button {
+    height: 50px;
+    margin: 20px 0 0;
+    color: black;
+    background-color: white;
+  }
+`;

--- a/client/src/components/admin/DeleteMedia.tsx
+++ b/client/src/components/admin/DeleteMedia.tsx
@@ -1,0 +1,37 @@
+import { useMutation } from '@tanstack/react-query';
+import styled from 'styled-components';
+import { AdminDeleteData } from '../../api/api';
+
+const DeleteMedia = ({ contentId }: { contentId: string }) => {
+  const DeleteMediaMutation = useMutation(() => AdminDeleteData(contentId), {
+    onSuccess: () => alert('삭제 완료'),
+  });
+
+  const handledelete = () => {
+    const input = window.prompt(`삭제하려면 "${contentId} 삭제"를 입력하세요.`);
+    if (input === `${contentId} 삭제`) {
+      DeleteMediaMutation.mutate();
+    } else {
+      alert('삭제 취소');
+    }
+  };
+
+  return (
+    <>
+      <S_DeleteBtn onClick={handledelete}>삭제</S_DeleteBtn>
+    </>
+  );
+};
+
+export default DeleteMedia;
+
+const S_DeleteBtn = styled.button`
+  position: absolute;
+  top: 10%;
+  right: 10%;
+  width: 50px;
+  height: 50px;
+  background-color: white;
+  border: 2px solid #000000;
+  border-radius: 10px;
+`;

--- a/client/src/components/authentication/SignupForm.tsx
+++ b/client/src/components/authentication/SignupForm.tsx
@@ -149,6 +149,7 @@ function SignupForm() {
         interests: [],
         memberId: 0,
         createdAt: '',
+        roles: [],
       });
     }
   };

--- a/client/src/components/comments/CommentContent.tsx
+++ b/client/src/components/comments/CommentContent.tsx
@@ -12,7 +12,7 @@ function CommentContent({ comment }: { comment: Comment }) {
   const [isEditing, setIsEditing] = useState(false);
   const [content, setContent] = useState(comment.content);
   const queryClient = useQueryClient();
-  const user = useQuery(['user'], GetUser);
+  const user = useQuery(['user'], GetUser, { enabled: false });
 
   const PatchMutation = useMutation(PatchComment, {
     onSuccess: () => queryClient.invalidateQueries(['comments']),

--- a/client/src/components/contents/ContentDetail.tsx
+++ b/client/src/components/contents/ContentDetail.tsx
@@ -7,12 +7,13 @@ import watcha from '../../assets/ott/watcha.svg';
 import wavve from '../../assets/ott/wavve.svg';
 import Bookmark from './Bookmark';
 import Tag from '../ui/Tag';
-import { GetDataDetail } from './../../api/api';
+import { GetDataDetail, GetUser } from './../../api/api';
 import Recommend from './Recommend';
 import {
   ContentDetailLoading,
   RecommendError,
 } from '../exceptions/contentDetail';
+import DeleteMedia from '../admin/DeleteMedia';
 
 const ContentDetail = ({ contentId }: { contentId: string }) => {
   const ottList = [
@@ -61,6 +62,8 @@ const ContentDetail = ({ contentId }: { contentId: string }) => {
     }
   };
 
+  const admin = useQuery(['user'], GetUser, { enabled: false });
+
   if (isLoading) return <ContentDetailLoading />;
 
   if (error instanceof Error) return <RecommendError />;
@@ -68,6 +71,9 @@ const ContentDetail = ({ contentId }: { contentId: string }) => {
   if (isSuccess) {
     return (
       <S_Wrapper backgroundimage={data.mainPoster}>
+        {admin?.data?.roles[0] === 'ADMIN' && (
+          <DeleteMedia contentId={contentId} />
+        )}
         <div className="main-flex">
           <div className="title-flex">
             <S_Title>

--- a/client/src/components/header/UserProfile.tsx
+++ b/client/src/components/header/UserProfile.tsx
@@ -5,10 +5,12 @@ import { styled } from 'styled-components';
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Dropdown from './Dropdown';
+import useIsLoggedIn from '../../hooks/useIsLoggedIn';
 
 function UserProfile() {
   const [showDropdown, setShowDropdown] = useState(false);
   const location = useLocation();
+  const isLoggedIn = useIsLoggedIn();
 
   useEffect(() => {
     setShowDropdown(false);
@@ -20,6 +22,7 @@ function UserProfile() {
     staleTime: Infinity,
     cacheTime: Infinity,
     refetchOnWindowFocus: false,
+    enabled: isLoggedIn,
   });
 
   if (isLoading)

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { GetUser } from '../api/api';
+import useIsLoggedIn from './../hooks/useIsLoggedIn';
+import AddMedia from '../components/admin/AddMedia';
+
+const Admin = () => {
+  const isLoggedIn = useIsLoggedIn();
+  const navigate = useNavigate();
+  const admin = useQuery(['user'], GetUser);
+
+  useEffect(() => {
+    if (!isLoggedIn || admin?.data?.roles[0] === 'USER') {
+      return navigate('/');
+    }
+  }, [isLoggedIn, admin, navigate]);
+
+  return (
+    <S_Wrapeer>
+      <AddMedia />
+    </S_Wrapeer>
+  );
+};
+
+export default Admin;
+
+const S_Wrapeer = styled.div`
+  width: 100%;
+  padding: 130px 0px 60px;
+`;

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -9,7 +9,7 @@ import AddMedia from '../components/admin/AddMedia';
 const Admin = () => {
   const isLoggedIn = useIsLoggedIn();
   const navigate = useNavigate();
-  const admin = useQuery(['user'], GetUser);
+  const admin = useQuery(['user'], GetUser, { enabled: false });
 
   useEffect(() => {
     if (!isLoggedIn || admin?.data?.roles[0] === 'USER') {
@@ -27,6 +27,7 @@ const Admin = () => {
 export default Admin;
 
 const S_Wrapeer = styled.div`
+  display: flex;
   width: 100%;
   padding: 130px 0px 60px;
 `;

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -14,6 +14,7 @@ export type NewMember = {
   category?: string;
   memberOtts?: string[];
   interests?: string[];
+  roles: string[];
 };
 
 export type LoginInfo = {
@@ -83,8 +84,27 @@ export type CommentData = {
   reviews: Comment[];
 };
 
+<<<<<<< Updated upstream
 export type Question = {
   isOpen: boolean;
   closeModal: () => void;
   onNextClick: () => void;
+=======
+export type AddData = {
+  title: string;
+  content: string;
+  category: string;
+  creator: string;
+  cast: string;
+  mainPoster: string;
+  titlePoster: string;
+  releaseDate: number;
+  ageRate: string;
+  recent: boolean;
+  genre: string[];
+  mediaOtt: {
+    ottName: string;
+    ottAddress: string;
+  }[];
+>>>>>>> Stashed changes
 };

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -84,12 +84,12 @@ export type CommentData = {
   reviews: Comment[];
 };
 
-<<<<<<< Updated upstream
 export type Question = {
   isOpen: boolean;
   closeModal: () => void;
   onNextClick: () => void;
-=======
+};
+
 export type AddData = {
   title: string;
   content: string;
@@ -106,5 +106,4 @@ export type AddData = {
     ottName: string;
     ottAddress: string;
   }[];
->>>>>>> Stashed changes
 };


### PR DESCRIPTION
관리자 계정 기능 추가, 페이지 추가, 리액트 훅 폼 인스톨
api 추가, 타입 추가, 변경

게시물 생성 => placeholder에 양식 작성 완료,
게시물 삭제 => 디테일 페이지에서 관리자만 삭제 버튼 생성, 경고 메세지

유저프로필 useQuery를 enabled: isLoggedIn 값으로 변경
 (로그인 안했을 경우 에러콘솔 제거)

다른 컴포넌트에서 호출시 enabled: false를 주고 isLoggedIn을 참조하게 변경
const user = useQuery(['user'], GetUser, { enabled: false });

NewMember 타입에 roles: string[]; 추가, Signup 컴포넌트에 roles: [] 추가