### PR TITLE
feat: 추천해조잉 렌더 로직 일부 수정

### DIFF
--- a/client/src/components/banner/MainBanner.tsx
+++ b/client/src/components/banner/MainBanner.tsx
@@ -47,7 +47,6 @@ function MainBanner() {
           </div>
           <PiCaretRightThin className="arrow" />
         </div>
-        {/* todo: Recommend 컴포넌트 외부로 조건부 렌더 로직 옮기기 */}
         <div onClick={() => openModal({ content: <Recommend /> })}>
           <div>
             <PiMagicWandFill />

--- a/client/src/components/header/Navigation.tsx
+++ b/client/src/components/header/Navigation.tsx
@@ -1,8 +1,10 @@
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
-import { useSetRecoilState, useResetRecoilState } from 'recoil';
-import { recommendModalState, recommendedContentsState } from '../../recoil/atoms/Atoms';
+import { useResetRecoilState } from 'recoil';
+import { recommendedContentsState } from '../../recoil/atoms/Atoms';
+import { useModal } from '../../hooks/useModal';
+import Recommend from '../modal/Recommend';
 
 const navMenus = [
   { text: 'TV', route: '/tv' },
@@ -11,9 +13,10 @@ const navMenus = [
 ];
 
 function Navigation() {
-  const setIsRecommendModal = useSetRecoilState(recommendModalState);
-  const resetRecommendedContents = useResetRecoilState(recommendedContentsState);
-
+  const resetRecommendedContents = useResetRecoilState(
+    recommendedContentsState
+  );
+  const { openModal } = useModal();
   const navigate = useNavigate();
   const pathname = useLocation().pathname;
   return (
@@ -23,7 +26,7 @@ function Navigation() {
           key={menu.text}
           onClick={() => {
             if (menu.route === null) {
-              setIsRecommendModal(true);
+              openModal({ content: <Recommend /> });
               resetRecommendedContents();
             } else {
               navigate(menu.route);

--- a/client/src/components/modal/Recommend.tsx
+++ b/client/src/components/modal/Recommend.tsx
@@ -1,16 +1,23 @@
 import { useState } from 'react';
-import { useRecoilState, useResetRecoilState } from "recoil";
-import { recommendModalState, recommendedContentsState } from "../../recoil/atoms/Atoms";
+import { useRecoilState, useResetRecoilState } from 'recoil';
+import {
+  recommendModalState,
+  recommendedContentsState,
+} from '../../recoil/atoms/Atoms';
 import styled from 'styled-components';
 import FirstQuestion from './questions/FirstQuestion';
 import SecondQuestion from './questions/SecondQuestion';
 import ThirdQuestion from './questions/ThirdQuestion';
-import QuestionResult from './questions/QuestionResult'
+import QuestionResult from './questions/QuestionResult';
+import { useModal } from '../../hooks/useModal';
 
 const Recommend = () => {
-  const [isRecommendModal, setIsRecommendModal] = useRecoilState(recommendModalState);
-  const resetRecommendedContents = useResetRecoilState(recommendedContentsState);
+  const [isRecommendModal] = useRecoilState(recommendModalState);
+  const resetRecommendedContents = useResetRecoilState(
+    recommendedContentsState
+  );
   const [currentQuestion, setCurrentQuestion] = useState(1);
+  const { closeModal } = useModal();
 
   const questionComponents = [
     FirstQuestion,
@@ -19,15 +26,9 @@ const Recommend = () => {
     QuestionResult,
   ];
 
-  const closeModal = () => {
-    setIsRecommendModal(false);
+  const resetModal = () => {
+    closeModal();
     setCurrentQuestion(1);
-  };
-
-  const closeModalOnOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      closeModal();
-    }
   };
 
   const handleNextClick = () => {
@@ -35,30 +36,29 @@ const Recommend = () => {
   };
 
   const handleReset = () => {
-    setCurrentQuestion(1)
+    setCurrentQuestion(1);
     resetRecommendedContents();
   };
 
   return (
-    isRecommendModal && (
-      <S_Wrapper onClick={closeModalOnOutsideClick}>
-        {questionComponents.map((Question, index) => (
+    <S_Wrapper onClick={() => closeModal()}>
+      {questionComponents.map(
+        (Question, index) =>
           currentQuestion === index + 1 && (
             <Question
               key={index}
               isOpen={isRecommendModal}
-              closeModal={closeModal}
+              closeModal={resetModal}
               onNextClick={handleNextClick}
               onReset={handleReset}
             />
           )
-        ))}
-      </S_Wrapper>
-    )
+      )}
+    </S_Wrapper>
   );
-}
+};
 
-export default Recommend
+export default Recommend;
 
 const S_Wrapper = styled.div`
   display: flex;

--- a/client/src/pages/Root.tsx
+++ b/client/src/pages/Root.tsx
@@ -4,7 +4,6 @@ import Footer from '../components/ui/Footer';
 import { S_Root, S_Wrapper, S_Container } from '../styles/style';
 import { useEffect } from 'react';
 import { logout } from '../components/header/Dropdown';
-import Recommend from '../components/modal/Recommend';
 import Modal from '../components/ui/modal/Modal';
 
 function Root() {
@@ -21,7 +20,6 @@ function Root() {
         <S_Container>
           <Outlet />
           <Modal />
-          <Recommend />
         </S_Container>
       </S_Wrapper>
       <Footer />


### PR DESCRIPTION
### PR에 관한 간략한 설명
Recommend 컴포넌트 내부에서 조건부 렌더링 로직을 없애고 바로 컴포넌트를 리턴하도록 했습니다.
헤더와 메인 배너 내비게이션 버튼에서 더 쉽게 컴포넌트에 접근하도록 만들기 위한 조치입니다.

### 기능 구현 및 수정 세부 사항
- [x] Recommend 컴포넌트에서 조건부 렌더링 로직을 삭제
- [x] useModal을 사용해 모달을 열고 닫는 액션을 일부 구현했습니다.

#### 미완료된 기능
- [ ] useModal을 사용해 전역 상태에 전혀 의존하지 않는 모달창으로 리팩터링

### 수정 사항 확인 방법