### PR TITLE
fix: 500 에러 컴포넌트 리턴 방식에서 경로 navigate으로 변경

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -77,6 +77,10 @@ const router = createBrowserRouter([
         path: 'admin',
         element: <Admin />,
       },
+      {
+        path: 'error',
+        element: <Error code="500" />,
+      },
     ],
   },
 ]);

--- a/client/src/components/slide/SlideMovie.tsx
+++ b/client/src/components/slide/SlideMovie.tsx
@@ -1,4 +1,3 @@
-import Error from '../../pages/Error';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { GetMovieData } from '../../api/api';
@@ -10,11 +9,13 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 // install Virtual module
 SwiperCore.use([Virtual, Navigation]);
 
 const SlideMovie = ({ genre }: { genre: string }) => {
+  const navigate = useNavigate();
   const [, setSwiperRef] = useState<SwiperCore | null>(null);
 
   const { isLoading, error, data, isSuccess } = useQuery({
@@ -35,8 +36,7 @@ const SlideMovie = ({ genre }: { genre: string }) => {
   }
 
   if (error instanceof AxiosError) {
-    if (!error.status && error.code === 'ERR_NETWORK')
-      return <Error code="500" />;
+    if (!error.status && error.code === 'ERR_NETWORK') navigate('/error');
   }
 
   if (isSuccess) {

--- a/client/src/components/slide/SlideTV.tsx
+++ b/client/src/components/slide/SlideTV.tsx
@@ -1,4 +1,3 @@
-import Error from '../../pages/Error';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { GetTVData } from '../../api/api';

--- a/client/src/components/slide/SlideTV.tsx
+++ b/client/src/components/slide/SlideTV.tsx
@@ -10,11 +10,13 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 // install Virtual module
 SwiperCore.use([Virtual, Navigation]);
 
 const SildeTV = ({ genre }: { genre: string }) => {
+  const navigate = useNavigate();
   const [, setSwiperRef] = useState<SwiperCore | null>(null);
 
   const { isLoading, error, data, isSuccess } = useQuery({
@@ -36,8 +38,7 @@ const SildeTV = ({ genre }: { genre: string }) => {
   }
 
   if (error instanceof AxiosError) {
-    if (!error.status && error.code === 'ERR_NETWORK')
-      return <Error code="500" />;
+    if (!error.status && error.code === 'ERR_NETWORK') navigate('/error');
   }
 
   if (isSuccess) {


### PR DESCRIPTION
### PR에 관한 간략한 설명
tv/영화페이지에서 500 오류시 '/error' 경로로 이동하도록 수정했습니다.

### 기능 구현 및 수정 세부 사항
500에러시 각 슬라이더에서 컴포넌트를 리턴하도록 잘못 코드를 짜서 navigate 방식으로 변경했습니다.

### 수정 사항 확인 방법
'/error' 경로로 이동하면 500에러시 뜨는 페이지를 확인할 수 있습니다.