### PR TITLE
📱 Fix/slider: 반응형 ui 구현 및 Layout Shift 현상 해결

### DIFF
--- a/client/src/components/banner/Banner.tsx
+++ b/client/src/components/banner/Banner.tsx
@@ -38,9 +38,9 @@ const S_ImageBox = styled.div`
 const S_BannerImage = styled.img`
   object-fit: cover;
   width: 100%;
-  height: 100%; /*height 추가*/
-  min-width: 0; /*추가*/
-  min-height: 0; /*추가*/
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
 `
 
 const S_BlackLinear = styled.div`

--- a/client/src/components/banner/Banner.tsx
+++ b/client/src/components/banner/Banner.tsx
@@ -13,11 +13,34 @@ export default Banner;
 
 const S_ImageBox = styled.div`
   position: relative; 
+  display: flex;
+  justify-content: center;
   width: 100%;
+  height: 660px;
+
+  @media only screen and (max-width: 1200px) {
+    height: 500px;
+  }
+
+  @media only screen and (max-width: 1024px) {
+    height: 350px;
+  }
+  
+  @media only screen and (max-width: 770px) {
+    height: 260px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    height: 180px;
+  }
 `;
 
 const S_BannerImage = styled.img`
   object-fit: cover;
+  width: 100%;
+  height: 100%; /*height 추가*/
+  min-width: 0; /*추가*/
+  min-height: 0; /*추가*/
 `
 
 const S_BlackLinear = styled.div`

--- a/client/src/components/contents/RecommendContent.tsx
+++ b/client/src/components/contents/RecommendContent.tsx
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { GetDataDetail, GetFilterdData } from '../../api/api';
 import styled from 'styled-components';
 import ItemCard from '../ui/ItemCard';
-// import SliderLoading from '../ui/exceptions/sliderLoading';
 import { RecommendContentLoading } from '../ui/exceptions/recommendContent';
 import { ContentData } from '../../types/types';
 
@@ -73,7 +72,6 @@ const S_ItemBox = styled.div`
 `;
 
 const S_Item = styled.div`
-  /* width: 225px; */
   width: calc(100% / 6 - 15px);
   margin: 0px 7.5px 50px;
 

--- a/client/src/components/contents/RecommendContent.tsx
+++ b/client/src/components/contents/RecommendContent.tsx
@@ -2,7 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { GetDataDetail, GetFilterdData } from '../../api/api';
 import styled from 'styled-components';
 import ItemCard from '../ui/ItemCard';
-import SkeletonItemCard from '../ui/SkeletonItemCard';
+// import SliderLoading from '../ui/exceptions/sliderLoading';
+import { RecommendContentLoading } from '../ui/exceptions/recommendContent';
 import { ContentData } from '../../types/types';
 
 const RecommendContent = ({ contentId }: { contentId: string }) => {
@@ -23,18 +24,10 @@ const RecommendContent = ({ contentId }: { contentId: string }) => {
 
   if (detailLoading || filteredLoading) {
     return (
-      <>
+      <S_Wrapper>
         <S_Text>이런 컨텐츠는 어떠세요?</S_Text>
-        <S_Wrapper>
-          <S_SkeletonBox>
-            {Array.from({ length: 6 }, (_, index) => (
-              <S_Item key={index}>
-                <SkeletonItemCard />
-              </S_Item>
-            ))}
-          </S_SkeletonBox>
-        </S_Wrapper>
-      </>
+        <RecommendContentLoading />
+      </S_Wrapper>
     );
   }
 
@@ -44,16 +37,16 @@ const RecommendContent = ({ contentId }: { contentId: string }) => {
   
   if (detailSuccess && filteredSuccess) {
     return (
-      <>
+      <S_Wrapper>
         <S_Text>이런 컨텐츠는 어떠세요?</S_Text>
-        <S_Wrapper>
+        <S_ItemBox>
           {filteredData?.content.map((item: ContentData) => (
             <S_Item key={item.id}>
               <ItemCard item={item} />
             </S_Item>
           ))}
-        </S_Wrapper>
-      </>
+        </S_ItemBox>
+      </S_Wrapper>
     );
   }
 
@@ -63,26 +56,44 @@ const RecommendContent = ({ contentId }: { contentId: string }) => {
 export default RecommendContent;
 
 const S_Wrapper = styled.div`
-  display: flex;
-  width: 100vw;
   padding: 0px 30px;
 `;
 
 const S_Text = styled.p`
-  margin: 28px 0 10px 0;
-  padding: 0px 30px;
+  margin: 28px 0 20px 0;
   color: var(--color-white-100);
   font-size: 24px;
   font-weight: 700;
 `;
 
-const S_Item = styled.div`
-  width: 225px;
-  margin: 0 7.5px 50px;
-  margin-top: 10px;
+const S_ItemBox = styled.div`
+  display: flex;
+  width: 100vw;
+  flex-wrap: wrap;
 `;
 
-const S_SkeletonBox = styled.div`
-  display: flex;
-  margin-bottom: 3.75rem;
+const S_Item = styled.div`
+  /* width: 225px; */
+  width: calc(100% / 6 - 15px);
+  margin: 0px 7.5px 50px;
+
+  @media only screen and (max-width: 1200px) {
+    width: calc(100% / 6 - 15px);
+    gap: 18px;
+  }
+
+  @media only screen and (max-width: 1024px) {
+    width: calc(100% / 5 - 15px);
+    gap: 16px;
+  }
+  
+  @media only screen and (max-width: 770px) {
+    width: calc(100% / 4 - 15px);
+    gap: 14px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    width: calc(100% / 3 - 15px);
+    gap: 10px;
+  }
 `;

--- a/client/src/components/slide/SlideMovie.tsx
+++ b/client/src/components/slide/SlideMovie.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { GetMovieData } from '../../api/api';
 import ItemCard from '../ui/ItemCard';
-import SkeletonItemCard from '../ui/SkeletonItemCard';
+import SliderLoading from '../ui/exceptions/sliderLoading';
 import styled from 'styled-components';
 import SwiperCore, { Virtual, Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -18,6 +18,14 @@ const SlideMovie = ({ genre }: { genre: string }) => {
   const navigate = useNavigate();
   const [, setSwiperRef] = useState<SwiperCore | null>(null);
 
+  const breakpoints = {
+    0: { slidesPerView: 3, slidesPerGroup: 2, spaceBetween: 10 },
+    480: { slidesPerView: 3, slidesPerGroup: 2, spaceBetween: 10 },
+    770: { slidesPerView: 4, slidesPerGroup: 3, spaceBetween: 14 },
+    1024: { slidesPerView: 5, slidesPerGroup: 4, spaceBetween: 16 },
+    1200: { slidesPerView: 6, slidesPerGroup: 5, spaceBetween: 18 }
+  };
+
   const { isLoading, error, data, isSuccess } = useQuery({
     queryKey: ['movieData', genre],
     queryFn: () => GetMovieData(genre),
@@ -25,14 +33,10 @@ const SlideMovie = ({ genre }: { genre: string }) => {
 
   if (isLoading) {
     return (
-      <S_Wrapper>
-        <S_SkeletonBox>
-          {Array.from({ length: 6 }, (_, index) => (
-            <SkeletonItemCard key={index} />
-          ))}
-        </S_SkeletonBox>
-      </S_Wrapper>
-    );
+      <S_LoadingBox>
+        <SliderLoading />
+      </S_LoadingBox>
+    )
   }
 
   if (error instanceof AxiosError) {
@@ -49,7 +53,8 @@ const SlideMovie = ({ genre }: { genre: string }) => {
           centeredSlides={false} // 센터 모드
           spaceBetween={18} // 슬라이드 사이 여백
           navigation={true} // 버튼
-          watchOverflow={true}
+          watchOverflow={true} // 슬라이드가 1개 일 때 pager, button 숨김 여부 설정
+          breakpoints={breakpoints}
           virtual
         >
           {data.content.map((item) => (
@@ -101,6 +106,10 @@ const S_Swiper = styled(Swiper)`
     right: -3.75rem;
   }
 
+  .swiper-button-disabled {
+    display: none; // 처음, 마지막 슬라이드에 도달하면 화살표 비활성화
+  }
+
   &:hover {
     .swiper-button-prev,
     .swiper-button-next {
@@ -115,8 +124,7 @@ const S_SwiperSlide = styled(SwiperSlide)`
   cursor: pointer;
 `;
 
-const S_SkeletonBox = styled.div`
-  display: flex;
-  gap: 18px;
-  margin-bottom: 3.75rem;
+const S_LoadingBox = styled.div`
+  margin-top: 15px;
+  padding: 0px 3.75rem;
 `;

--- a/client/src/components/slide/SlideTV.tsx
+++ b/client/src/components/slide/SlideTV.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { GetTVData } from '../../api/api';
 import ItemCard from '../ui/ItemCard';
-import SkeletonItemCard from '../ui/SkeletonItemCard';
+import SliderLoading from '../ui/exceptions/sliderLoading';
 import styled from 'styled-components';
 import SwiperCore, { Virtual, Navigation } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -18,6 +18,14 @@ const SildeTV = ({ genre }: { genre: string }) => {
   const navigate = useNavigate();
   const [, setSwiperRef] = useState<SwiperCore | null>(null);
 
+  const breakpoints = {
+    0: { slidesPerView: 3, slidesPerGroup: 2, spaceBetween: 10 },
+    480: { slidesPerView: 3, slidesPerGroup: 2, spaceBetween: 10 },
+    770: { slidesPerView: 4, slidesPerGroup: 3, spaceBetween: 14 },
+    1024: { slidesPerView: 5, slidesPerGroup: 4, spaceBetween: 16 },
+    1200: { slidesPerView: 6, slidesPerGroup: 5, spaceBetween: 18 }
+  };
+
   const { isLoading, error, data, isSuccess } = useQuery({
     queryKey: ['tvData', genre],
     queryFn: () => GetTVData(genre),
@@ -26,14 +34,10 @@ const SildeTV = ({ genre }: { genre: string }) => {
 
   if (isLoading) {
     return (
-      <S_Wrapper>
-        <S_SkeletonBox>
-          {Array.from({ length: 6 }, (_, index) => (
-            <SkeletonItemCard key={index} />
-          ))}
-        </S_SkeletonBox>
-      </S_Wrapper>
-    );
+      <S_LoadingBox>
+        <SliderLoading />
+      </S_LoadingBox>
+    )
   }
 
   if (error instanceof AxiosError) {
@@ -51,6 +55,7 @@ const SildeTV = ({ genre }: { genre: string }) => {
           spaceBetween={18} // 슬라이드 사이 여백
           navigation={true} // 버튼
           watchOverflow={true}
+          breakpoints={breakpoints}
           virtual
         >
           {data.content.map((item) => (
@@ -102,6 +107,10 @@ const S_Swiper = styled(Swiper)`
     right: -3.75rem;
   }
 
+  .swiper-button-disabled {
+    display: none; // 처음, 마지막 슬라이드에 도달하면 화살표 비활성화
+  }
+
   &:hover {
     .swiper-button-prev,
     .swiper-button-next {
@@ -116,8 +125,7 @@ const S_SwiperSlide = styled(SwiperSlide)`
   cursor: pointer;
 `;
 
-const S_SkeletonBox = styled.div`
-  display: flex;
-  gap: 18px;
-  margin-bottom: 3.75rem;
+const S_LoadingBox = styled.div`
+  margin-top: 15px;
+  padding: 0px 3.75rem;
 `;

--- a/client/src/components/ui/ItemCard.tsx
+++ b/client/src/components/ui/ItemCard.tsx
@@ -43,4 +43,20 @@ const S_ItemTitle = styled.p`
   font-size: 18px;
   font-weight: 700;
   filter: var(--shadow-l-25);
+
+  @media only screen and (max-width: 1200px) {
+    font-size: 18px;
+  }
+
+  @media only screen and (max-width: 1024px) {
+    font-size: 16px;
+  }
+  
+  @media only screen and (max-width: 770px) {
+    font-size: 14px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 13px;
+  }
 `;

--- a/client/src/components/ui/exceptions/recommendContent.tsx
+++ b/client/src/components/ui/exceptions/recommendContent.tsx
@@ -1,0 +1,89 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import SkeletonItemCard from '../SkeletonItemCard';
+import { ItemProps } from '../../../types/types';
+
+export function RecommendContentLoading() {
+  const [size, setSize] = useState(getSize());
+
+  function getSize() {
+    const width = window.innerWidth;
+
+    if (width <= 480) {
+      return 3;
+    } else if (width <= 770) {
+      return 4;
+    } else if (width <= 1024) {
+      return 5;
+    } else {
+      return 6;
+    }
+  }
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSize(getSize());
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return (
+    <S_LoadingWrap>
+      {Array.from({ length: size }, (_, index) => (
+        <S_Item key={index} index={index + 1} size={size}>
+          <SkeletonItemCard />
+        </S_Item>
+      ))}
+    </S_LoadingWrap>
+  );
+}
+
+const S_LoadingWrap = styled.div`
+  width: calc(100vw - 40px);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+
+  .target {
+    height: 10px;
+  }
+
+  @media only screen and (max-width: 1500px) {
+    padding: 0;
+  }
+`;
+
+const S_Item = styled.div<ItemProps>`
+  width: 225px;
+  margin: 0px 7.5px 50px;
+  flex-grow: 1;
+
+  @media only screen and (max-width: 1200px) {
+    width: 14vw;
+    margin: ${({ index }) =>
+      index % 6 === 0 ? '0 0 50px 0' : '0 18px 50px 0'};
+  }
+
+  @media only screen and (max-width: 1024px) {
+    width: 17vw;
+    margin: ${({ index }) =>
+      index % 5 === 0 ? '0 0 30px 0' : '0 16px 30px 0'};
+  }
+
+  @media only screen and (max-width: 770px) {
+    width: 18vw;
+    margin: ${({ index }) =>
+      index % 4 === 0 ? '0 0 30px 0' : '0 14x 30px 0'};
+  }
+
+  @media only screen and (max-width: 480px) {
+    width: 23vw;
+    margin: ${({ index }) =>
+      index % 3 === 0 ? '0 0 30px 0' : '0 10px 30px 0'};
+  }
+`;

--- a/client/src/components/ui/exceptions/sliderLoading.tsx
+++ b/client/src/components/ui/exceptions/sliderLoading.tsx
@@ -48,7 +48,6 @@ const S_Wrapper = styled.div`
   position: relative;
   overflow-x: hidden; // 가로 스크롤 숨김
   margin: 0;
-  /* padding: 0px 3.75rem; */
   width: 100%;
 `;
 

--- a/client/src/components/ui/exceptions/sliderLoading.tsx
+++ b/client/src/components/ui/exceptions/sliderLoading.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import SkeletonItemCard from '../../ui/SkeletonItemCard'
+import styled from 'styled-components';
+
+const sliderLoading = () => {
+  const getSkeletonSize = () => {
+    const width = window.innerWidth;
+
+    if (width < 770) {
+      return { size: 3, gap: 10 };
+    } else if (width < 1024) {
+      return { size: 4, gap: 14 };
+    } else if (width < 1200) {
+      return { size: 5, gap: 16 };
+    } else {
+      return { size: 6, gap: 18 };
+    }
+  };
+
+  const [skeletonSize, setSkeletonSize] = useState(getSkeletonSize());
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSkeletonSize(getSkeletonSize());
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return (
+    <S_Wrapper>
+      <S_SkeletonBox gap={skeletonSize.gap}>
+        {Array.from({ length: skeletonSize.size }, (_, index) => (
+          <SkeletonItemCard key={index} />
+        ))}
+      </S_SkeletonBox>
+    </S_Wrapper>
+  );
+}
+
+export default sliderLoading
+
+const S_Wrapper = styled.div`
+  position: relative;
+  overflow-x: hidden; // 가로 스크롤 숨김
+  margin: 0;
+  /* padding: 0px 3.75rem; */
+  width: 100%;
+`;
+
+const S_SkeletonBox = styled.div<{ gap: number }>`
+  display: flex;
+  gap: ${(props) => props.gap}px;
+  margin-bottom: 3.75rem;
+`;


### PR DESCRIPTION
## 기능 구현
- [x]  슬라이더 화살표 비활성화
    - 첫 슬라이드 : 왼쪽 화살표 비활성화
    - 마지막 슬라이드 : 오른쪽 화살표 비활성화

- [x]  반응형 ui 구현
    - TV, movie 페이지의 슬라이더
    - 상세 조회 페이지의 ItemCard
    - 화면의 너비에 따라 보여지는 슬라이드 개수가 달라짐

- [x]  스켈레톤 반응형 ui 구현
    - TV, movie, 상세 조회 페이지의 ItemCard
    - 화면의 너비에 따라 보여지는 ItemCard 개수가 달라짐
    
- [x]  Layout Shift 현상
    - TV, movie 페이지의 배너
    - 화면의 너비에 따라 이미지 영역을 잡아두었다.