### PR TITLE
:sparkles: Fix: 상세 조회 페이지 추천 컨텐츠 필터링 수정, 정렬방식 변경

### DIFF
--- a/client/src/components/contents/RecommendContent.tsx
+++ b/client/src/components/contents/RecommendContent.tsx
@@ -6,6 +6,11 @@ import { RecommendContentLoading } from '../ui/exceptions/recommendContent';
 import { ContentData } from '../../types/types';
 
 const RecommendContent = ({ contentId }: { contentId: string }) => {
+  const getRandomItems = (items: ContentData[], numItems: number) => {
+    const shuffledItems = items.sort(() => 0.5 - Math.random());
+    return shuffledItems.slice(0, numItems);
+  };
+
   const {
     isLoading: detailLoading,
     error: detailError,
@@ -27,7 +32,7 @@ const RecommendContent = ({ contentId }: { contentId: string }) => {
     queryKey: ['filteredContent', contentId],
     queryFn: () =>
       GetFilterdData(
-        `/medias/${category}?size=6&genre=${detailData?.genre.join(',')}`
+        `/medias/${category}?genre=${detailData?.genre.join(',')}`
       ),
     enabled: !!detailData, // true가 되면 filteredData를 실행한다
   });
@@ -48,11 +53,15 @@ const RecommendContent = ({ contentId }: { contentId: string }) => {
     return 'An error has occurred: ' + filteredError.message;
 
   if (detailSuccess && filteredSuccess) {
+
+    const randomItems = getRandomItems(filteredData?.content, 6);
+
     return (
       <S_Wrapper>
         <S_Text>이런 컨텐츠는 어떠세요?</S_Text>
         <S_ItemBox>
-          {filteredData?.content.map((item: ContentData) => (
+          {/* {filteredData?.content.map((item: ContentData) => ( */}
+          {randomItems.map((item: ContentData) => (
             <S_Item key={item.id}>
               <ItemCard item={item} />
             </S_Item>
@@ -93,12 +102,12 @@ const S_Item = styled.div`
   }
 
   @media only screen and (max-width: 1024px) {
-    width: calc(100% / 5 - 15px);
+    width: calc(100% / 6 - 15px);
     gap: 16px;
   }
 
   @media only screen and (max-width: 770px) {
-    width: calc(100% / 4 - 15px);
+    width: calc(100% / 3 - 15px);
     gap: 14px;
   }
 


### PR DESCRIPTION
## 수정 사항
- [x] 상세 조회 페이지 필터링된 추천 컨텐츠
index순으로 6개 보여주기 ->  랜덤으로 6개 보여주기로 변경

- [x] 컨텐츠 정렬 방식
데스크탑은 1줄로 6개, 모바일은 2줄로 3개씩 보여주기
- 데스크탑 기준
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/27b8855f-31c8-4c55-bb03-b70790170049)
- 모바일 기준
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/74f6fcaa-67d7-4793-9280-32899826a1a4)
