### PR TITLE
:iphone: Fix: 추천해조잉 모달창 반응형 ui 구현

### DIFF
--- a/client/src/components/ui/CloseBtn.tsx
+++ b/client/src/components/ui/CloseBtn.tsx
@@ -22,4 +22,16 @@ const S_Close = styled(IoClose)`
   color: var(--color-white-100);
   font-size: 50px;
   cursor: pointer;
+
+  @media only screen and (max-width: 1200px) {
+    font-size: 50px;
+  }
+
+  @media only screen and (max-width: 770px) {
+    font-size: 40px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 30px;
+  }
 `;

--- a/client/src/components/ui/CloseBtn.tsx
+++ b/client/src/components/ui/CloseBtn.tsx
@@ -18,7 +18,7 @@ export default CloseBtn
 const S_Close = styled(IoClose)`
   position: absolute;
   top: 15%;
-  right: 0%;
+  right: 5%;
   color: var(--color-white-100);
   font-size: 50px;
   cursor: pointer;

--- a/client/src/components/ui/QuestionCard.tsx
+++ b/client/src/components/ui/QuestionCard.tsx
@@ -23,7 +23,15 @@ const S_Wrapper = styled.div`
   flex-direction: column;
 `
 const S_Character = styled.img`
-  height: 180px;
+  height: 150px;
+
+  @media only screen and (max-width: 770px) {
+    height: 130px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    height: 100px;
+  }
 `
 
 const S_Question = styled.img`

--- a/client/src/components/ui/RecommendBtn.tsx
+++ b/client/src/components/ui/RecommendBtn.tsx
@@ -65,4 +65,16 @@ const S_Button = styled.button<{ bgColor: string, bgShadow: string, disabled?: b
 
 const S_ButtonText = styled.img`
   margin: 0 15px;
+  height: 30px;
+  @media only screen and (max-width: 1200px) {
+    height: 30px;
+  }
+
+  @media only screen and (max-width: 770px) {
+    height: 25px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    height: 18px;
+  }
 `

--- a/client/src/components/ui/questions/FirstQuestion.tsx
+++ b/client/src/components/ui/questions/FirstQuestion.tsx
@@ -93,6 +93,19 @@ const S_ModalBox = styled.div`
   flex-direction: column;
   width: 820px;
   height: 100%;
+  font-family: 'inter';
+  font-size: 18px;
+  font-weight: 700;
+
+  @media only screen and (max-width: 770px) {
+    width: 620px;
+    font-size: 16px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    width: 330px;
+    font-size: 12px;
+  }
 `;
 
 const S_ModalBackground = styled.div`
@@ -114,7 +127,6 @@ const S_SelectionBox = styled.div`
   border: 5px solid var(--color-bg-100);
   border-radius: 15px;
   box-shadow: 4px 4px 10px 0px rgba(0, 0, 0, 0.4);
-  font-family: 'inter';
 `;
 
 const S_TextBox = styled.div`
@@ -123,17 +135,25 @@ const S_TextBox = styled.div`
 `;
 
 const S_Text = styled.p`
-  font-size: 18px;
-  font-weight: 700;
   color: var(--color-bg-100);
 `;
 
 const S_OttList = styled.div`
-  display: grid;
-  justify-content: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
   align-items: center;
   margin: 50px 50px 30px;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 18px;
+
+  @media only screen and (max-width: 770px) {
+    margin: 40px 40px 20px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    margin: 30px 30px 10px;
+    
+  }
 `;
 
 const S_OttBox = styled.div`
@@ -142,15 +162,16 @@ const S_OttBox = styled.div`
   align-items: center;
   flex-direction: column;
   margin-bottom: 15px;
+  width: calc(100% / 4 - 20px);
   color: var(--color-bg-100);
-  font-size: 18px;
-  font-weight: 700;
+
+  @media only screen and (max-width: 480px) {
+    width: calc(100% / 2 - 10px);
+  }
 `;
 
 const S_OttIcon = styled.img`
   margin-bottom: 5px;
-  width: 90px;
-  height: 90px;
   background: var(--color-white-100);
   object-fit: cover;
   border: 2px solid var(--color-bg-100);
@@ -159,6 +180,7 @@ const S_OttIcon = styled.img`
   opacity: 0.8;
   transition: filter 0.2s, opacity 0.2s;
   cursor: pointer;
+  width: 90px;
 
   &.select {
     filter: none;
@@ -167,6 +189,14 @@ const S_OttIcon = styled.img`
 
   &:hover {
     filter: brightness(100%);
+  }
+
+  @media only screen and (max-width: 770px) {
+    width: 70px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    width: 65px;
   }
 `;
 

--- a/client/src/components/ui/questions/QuestionData.tsx
+++ b/client/src/components/ui/questions/QuestionData.tsx
@@ -37,7 +37,7 @@ export const questionList = [
 
 export const ottServices = [
   { name: '넷플릭스', ottname: 'netfilx', icon: netflix,},
-  { name: '디즈니플러스', ottname: 'disney', icon: disney },
+  { name: '디즈니+', ottname: 'disney', icon: disney },
   { name: '왓챠', ottname: 'watcha', icon: watcha },
   { name: '웨이브', ottname: 'wavve', icon: wavve },
 ];
@@ -59,20 +59,13 @@ export const genres = [
   '액션',
   '드라마',
   'SF',
+  '판타지',
   '스릴러',
-  '애니메이션',
   '코미디',
   '가족',
-  '판타지',
+  '애니메이션',
   '로맨스',
   '공포',
   '범죄',
-  '스포츠',
-  '음악',
-  'Made in Europe',
-  'Reality TV',
   '역사',
-  '다큐멘터리',
-  '전쟁',
-  '서부',
 ];

--- a/client/src/components/ui/questions/QuestionResult.tsx
+++ b/client/src/components/ui/questions/QuestionResult.tsx
@@ -149,7 +149,7 @@ const QuestionResult: React.FC<Question> = ({ closeModal, onReset }) => {
             </S_ResultTitleBox>
             <S_SelectionBox>
               <S_RecommendBox>
-                <S_ResultImg src={beesad} />
+                <S_ResultAgainImg src={beesad} />
                 <S_Text>{`다시 컨텐츠를 찾아볼까요?`}</S_Text>
                 <S_BtnsBox>
                   <RecommendBtn
@@ -186,6 +186,14 @@ const S_ModalBox = styled.div`
   flex-direction: column;
   width: 800px;
   height: 100%;
+
+  @media only screen and (max-width: 770px) {
+    width: 580px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    width: 350px;
+  }
 `;
 
 const S_ModalBackground = styled.div`
@@ -199,18 +207,48 @@ const S_ModalBackground = styled.div`
 `;
 
 const S_SelectionBox = styled.div`
-  display: grid;
+  display: flex;
   justify-content: center;
-  padding: 20px 40px;
+  padding: 30px 40px;
   width: 100%;
   background: var(--color-white-100);
   border: 5px solid var(--color-bg-100);
   border-radius: 15px;
   box-shadow: 4px 4px 10px 0px rgba(0, 0, 0, 0.4);
   font-family: 'inter';
+
+  @media only screen and (max-width: 770px) {
+    display: grid;
+  }
+
+  @media only screen and (max-width: 480px) {
+    padding: 20px 20px;
+  }
 `;
 
-const S_ResultImg = styled.img``;
+const S_ResultImg = styled.img`
+  height: 70px;
+
+  @media only screen and (max-width: 770px) {
+    height: 60px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    height: 50px;
+  }
+`;
+
+const S_ResultAgainImg = styled.img`
+  height: 200px;
+
+  @media only screen and (max-width: 770px) {
+    height: 180px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    height: 150px;
+  }
+`;
 
 const S_ResultIdBox = styled.div`
   display: flex;
@@ -222,13 +260,21 @@ const S_ResultIdBox = styled.div`
 
 const S_ResultId = styled.p`
   font-family: 'cookieRun';
-  font-size: 60px;
+  font-size: 50px;
   font-weight: 700;
   color: #f7cd40;
   text-shadow: 0 0 0px #212121, 0 0 0px #212121, 0 0 0px #212121,
     0 0 0px #212121, 5px 0 0px #212121, 5px 5px 0px #212121,
     5px -5px 0px #212121, -5px 0 0px #212121, -5px 5px 0px #212121,
     -5px -5px 0px #212121;
+  
+  @media only screen and (max-width: 770px) {
+    font-size: 40px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 30px;
+  }
 `;
 
 const S_ResultTitleBox = styled.div`
@@ -241,13 +287,21 @@ const S_ResultTitleBox = styled.div`
 
 const S_ResultTitle = styled.p`
   font-family: 'cookieRun';
-  font-size: 60px;
+  font-size: 50px;
   font-weight: 700;
   color: #f7cd40;
   text-shadow: 0 0 0px #212121, 0 0 0px #212121, 0 0 0px #212121,
     0 0 0px #212121, 5px 0 0px #212121, 5px 5px 0px #212121,
     5px -5px 0px #212121, -5px 0 0px #212121, -5px 5px 0px #212121,
     -5px -5px 0px #212121;
+
+  @media only screen and (max-width: 770px) {
+    font-size: 40px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 30px;
+  }
 `;
 
 const S_RecommendBox = styled.div`
@@ -264,7 +318,6 @@ const S_RecommendPosterBox = styled.div`
 `;
 
 const S_RecommendPoster = styled.img`
-  width: 220px;
   height: 300px;
   background: var(--color-white-100);
   object-fit: cover;
@@ -272,7 +325,17 @@ const S_RecommendPoster = styled.img`
   border: 3px solid var(--color-bg-100);
   filter: var(--shadow-modal-m-b);
   border-radius: 10px;
-  margin-bottom: 20px;
+  margin-right: 40px;
+
+  @media only screen and (max-width: 770px) {
+    margin-bottom: 20px;
+    margin-right: 0px;
+    height: 250px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    height: 200px;
+  }
 `;
 
 const S_Text = styled.p`
@@ -283,12 +346,26 @@ const S_Text = styled.p`
   text-align: center;
   white-space: pre;
   color: var(--color-bg-100);
+
+  @media only screen and (max-width: 770px) {
+    font-size: 20px;
+    margin-bottom: 25px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 16px;
+    margin-bottom: 20px;
+  }
 `;
 
 const S_BtnsBox = styled.div`
   display: flex;
   justify-content: space-between;
   gap: 30px;
+
+  @media only screen and (max-width: 480px) {
+    gap: 20px;
+  }
 `;
 
 const opacityAnimation = keyframes`

--- a/client/src/components/ui/questions/SecondQuestion.tsx
+++ b/client/src/components/ui/questions/SecondQuestion.tsx
@@ -115,6 +115,14 @@ const S_CategoryList = styled.div`
   justify-content: center;
   align-items: center;
   gap: 80px;
+
+  @media only screen and (max-width: 770px) {
+    gap: 60px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    gap: 40px;
+  }
 `;
 
 const S_CategoryBox = styled.div`
@@ -125,12 +133,19 @@ const S_CategoryBox = styled.div`
   color: var(--color-bg-100);
   font-size: 18px;
   font-weight: 700;
+
+  @media only screen and (max-width: 770px) {
+    font-size: 16px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 12px;
+  }
 `;
 
 const S_CategoryIcon = styled.img`
   margin-bottom: 5px;
   width: 130px;
-  height: 130px;
   background: var(--color-white-100);
   object-fit: cover;
   filter: saturate(0);
@@ -145,5 +160,13 @@ const S_CategoryIcon = styled.img`
 
   &:hover {
     filter: brightness(100%);
+  }
+
+  @media only screen and (max-width: 770px) {
+    width: 120px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    width: 100px;
   }
 `;

--- a/client/src/components/ui/questions/ThirdQuestion.tsx
+++ b/client/src/components/ui/questions/ThirdQuestion.tsx
@@ -9,6 +9,8 @@ import CloseBtn from '../../ui/CloseBtn';
 import { questionList, genres } from './QuestionData';
 import { Question } from '../../../types/types';
 import btnNext from '../../../assets/recommendimage/nextBtnText.webp';
+import beehappy from '../../../assets/recommendimage/beehappy.svg';
+import beesad from '../../../assets/recommendimage/beesad.svg';
 
 const ThirdQuestion: React.FC<Question> = ({ closeModal, onNextClick }) => {
   const [recommendedContents, setRecommendedContents] = useRecoilState(
@@ -51,12 +53,13 @@ const ThirdQuestion: React.FC<Question> = ({ closeModal, onNextClick }) => {
             {genres.map((genre) => (
               <S_GenreBox key={genre}>
                 <S_CheckBox
+                  id={`check${genre}`}
                   checked={recommendedContents.interests.includes(genre)}
                   onChange={(e: ChangeEvent<HTMLInputElement>) =>
                     handleGenreCheckboxClick(e.target.checked, genre)
                   }
                 />
-                <div>{genre}</div>
+                <S_CheckText htmlFor={`check${genre}`}>{genre}</S_CheckText>
               </S_GenreBox>
             ))}
           </S_GenreList>
@@ -113,7 +116,18 @@ const S_SelectionBox = styled.div`
   border-radius: 15px;
   box-shadow: 4px 4px 10px 0px rgba(0, 0, 0, 0.4);
   font-family: 'inter';
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-bg-100);
   overflow: auto;
+
+  @media only screen and (max-width: 770px) {
+    font-size: 16px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    font-size: 12px;
+  }
 `;
 
 const S_TextBox = styled.div`
@@ -121,45 +135,64 @@ const S_TextBox = styled.div`
   justify-content: right;
 `;
 
-const S_Text = styled.p`
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--color-bg-100);
-`;
+const S_Text = styled.p``;
 
 const S_GenreList = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 35px 5px;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  margin: 30px 40px;
+  margin: 30px 20px;
+
+  @media only screen and (max-width: 770px) {
+    gap: 20px 5px;
+  }
+
+  @media only screen and (max-width: 480px) {
+    margin: 15px 10px;
+  }
 `;
 
 const S_GenreBox = styled.div`
   display: flex;
   align-items: center;
-  color: var(--color-bg-100);
-  font-size: 18px;
-  font-weight: 700;
+  width: calc(100% / 4 - 10px);
+
+  @media only screen and (max-width: 770px) {
+    width: calc(100% / 3 - 10px);
+  }
+
+  @media only screen and (max-width: 480px) {
+    justify-content: center;
+    flex-direction: column;
+  }
 `;
 
 const S_CheckBox = styled.input.attrs({ type: 'checkbox' })`
   margin-right: 10px;
-  width: 30px;
-  height: 30px;
+  width: 35px;
+  height: 35px;
   appearance: none;
-  background: var(--color-white-100);
-  object-fit: cover;
-  border: 2px solid var(--color-bg-100);
-  border-radius: 5px;
+  filter: saturate(0);
+  background-image: url(${beesad});
+  background-size: cover;
+  background-position: center;
+  opacity: 0.4;
+  transition: filter 0.1s, opacity 0.1s;
   cursor: pointer;
 
   &:checked {
-    background-color: #f7cd40;
+    background-image: url(${beehappy});
+    filter: none;
+    opacity: 1;
   }
 
-  &:hover {
-    background-color: #f7cd40;
+  @media only screen and (max-width: 480px) {
+    margin-right: 0px;
   }
+`;
+
+const S_CheckText = styled.label`
+  cursor: pointer;
 `;


### PR DESCRIPTION
## 수정 사항
- [x] 3번째 장르 선택 질문
  - 19개의 장르에서 12개로 변경 (장르가 별로 없는 기준으로 7개 제외)
  - 체크박스가 꿀벌 이미지로 변경
  
- [x] 추천해조잉 모달창 반응형 ui 구현
  - 데스크탑, 태블릿, 모바일 3가지 유형으로 나누어 구현함.
  - 아래 예시 이미지는 모바일 기준 ui
 
    - 질문 화면
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/f172b666-543a-4de1-9ff1-21b3295e144e)

    - 결과 화면
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/c32cc5a0-a8b4-4293-bb27-1095640cb27e)

