### PR TITLE
:zap: Fix: TV/Movie 페이지 배너 성능 개선

### DIFF
--- a/client/src/components/banner/Banner.tsx
+++ b/client/src/components/banner/Banner.tsx
@@ -1,38 +1,62 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
 const Banner = ({ image }: { image: string }) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  const handleImageLoad = () => {
+    setImageLoaded(true);
+  };
+
   return (
-    <S_ImageBox>
-      <S_BannerImage src={image} alt={image}/>
+    <S_Wrapper>
+      <S_SkeletonBox>
+        {!imageLoaded && <S_Skeleton />}
+      </S_SkeletonBox>
+      <S_BannerBox>
+        <S_BannerImage
+          src={image}
+          alt={image}
+          style={{ display: imageLoaded ? 'block' : 'none' }}
+          onLoad={handleImageLoad}
+        />
+      </S_BannerBox>
       <S_BlackLinear/>
-    </S_ImageBox>
+    </S_Wrapper>
   )
 }
 
 export default Banner;
 
-const S_ImageBox = styled.div`
+const S_Wrapper = styled.div`
   position: relative; 
   display: flex;
   justify-content: center;
   width: 100%;
-  height: 660px;
+  height: 0;
+  padding-bottom: calc(7 / 16 * 100%);
+`;
 
-  @media only screen and (max-width: 1200px) {
-    height: 500px;
-  }
+const S_SkeletonBox = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
 
-  @media only screen and (max-width: 1024px) {
-    height: 350px;
-  }
-  
-  @media only screen and (max-width: 770px) {
-    height: 260px;
-  }
+const S_Skeleton = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-dropdown);
+`;
 
-  @media only screen and (max-width: 480px) {
-    height: 180px;
-  }
+const S_BannerBox = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 `;
 
 const S_BannerImage = styled.img`


### PR DESCRIPTION
## 개선 사항
### 1. 화면 너비에 따라 배너가 잘려보이는 현상
- 컨테이너의 높이(S_Wrapper)를 0으로 설정하고 종횡비(16:7)에 따라 패딩 하단을 적용하여
이미지 크기가 변경되더라도 컨테이너가 원하는 종횡비를 유지하도록 함
  ```css
  padding-bottom: calc(7 / 16 * 100%);
  ```

<br>

### 2. Layout Shift 현상
- 이미지와 동일한 종횡비(16:7)로 스켈레톤 UI를 생성하여 이미지가 로드되는 동안 스켈레톤 UI를 표시
* 이미지 로드가 완료되면 스켈레톤 UI를 숨기고 이미지를 보여줌
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/f834cb1a-38e8-47fd-b175-8a7313f1ad35)


### 데스크탑 기준
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/e3750c71-1f94-4d73-a938-95a3e404a28c)

### 모바일 기준
![image](https://github.com/codestates-seb/seb44_main_003/assets/101691440/1e4eed71-0cde-4fa9-82c0-cc6322ffd350)
