### PR TITLE
Feat/header 헤더와 모바일GNB 스타일 변경

### DIFF
--- a/client/src/components/banner/MainBanner.tsx
+++ b/client/src/components/banner/MainBanner.tsx
@@ -69,16 +69,23 @@ const S_Wrapper = styled.div`
   display: flex;
   position: relative;
   overflow: hidden;
-  @media only screen and (max-width: 1095px) {
+  @media only screen and (max-width: 1024px) {
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
     height: 570px;
   }
-  @media only screen and (max-width: 480px) {
+  @media only screen and (max-width: 600px) {
     padding-top: 50px;
     height: 450px;
   }
+  & h1,
+  h2,
+  h3,
+  p {
+    min-width: max-content;
+  }
+
   & img {
     position: absolute;
     top: 0;
@@ -94,7 +101,7 @@ const S_Wrapper = styled.div`
     position: relative;
     margin-bottom: 50px;
     padding: 5px 80px;
-    @media only screen and (max-width: 1095px) {
+    @media only screen and (max-width: 1024px) {
       flex-grow: 1;
       align-items: center;
       margin-bottom: 0;
@@ -111,10 +118,10 @@ const S_Wrapper = styled.div`
       font-size: 30px;
       margin-bottom: 15px;
       animation: appear 1.5s linear -0.3s;
-      @media only screen and (max-width: 1213px) {
+      @media only screen and (max-width: 1024px) {
         font-size: 23px;
       }
-      @media only screen and (max-width: 665px) {
+      @media only screen and (max-width: 600px) {
         display: flex;
         flex-direction: column;
         font-size: 18px;
@@ -143,11 +150,11 @@ const S_Wrapper = styled.div`
           transform: translate(0, 0);
         }
       }
-      @media only screen and (max-width: 1213px) {
+      @media only screen and (max-width: 1024px) {
         font-size: 65px;
       }
 
-      @media only screen and (max-width: 665px) {
+      @media only screen and (max-width: 600px) {
         display: flex;
         flex-direction: column;
         font-size: 55px;
@@ -163,19 +170,19 @@ const S_Wrapper = styled.div`
     flex-grow: 1;
     align-items: end;
     z-index: 3;
-    @media only screen and (max-width: 1095px) {
+    @media only screen and (max-width: 1024px) {
       flex-direction: row;
       flex-grow: 0;
       width: 70vw;
       margin-right: 0;
       margin-bottom: 20px;
     }
-    @media only screen and (max-width: 900px) {
+    @media only screen and (max-width: 1024px) {
       width: 90vw;
     }
     > div:first-child {
       animation: appear-side 1.5s linear -0.7s;
-      @media only screen and (max-width: 1095px) {
+      @media only screen and (max-width: 1024px) {
         animation: appear-bottom 1.5s linear -0.7s;
       }
       @keyframes appear-side {
@@ -201,13 +208,13 @@ const S_Wrapper = styled.div`
     }
     > div:nth-child(2) {
       animation: appear-side 1.5s linear -0.5s;
-      @media only screen and (max-width: 1095px) {
+      @media only screen and (max-width: 1024px) {
         animation: appear-bottom 1.5s linear -0.7s;
       }
     }
     > div:nth-child(3) {
       animation: appear-side 1.5s linear -0.3s;
-      @media only screen and (max-width: 1095px) {
+      @media only screen and (max-width: 1024px) {
         animation: appear-bottom 1.5s linear -0.7s;
       }
     }
@@ -225,17 +232,17 @@ const S_Wrapper = styled.div`
       color: white;
       font-size: 17px;
       cursor: pointer;
-      @media only screen and (max-width: 1277px) {
+      @media only screen and (max-width: 1024px) {
         width: 350px;
       }
-      @media only screen and (max-width: 1095px) {
+      @media only screen and (max-width: 1024px) {
         margin: 0 5px;
         height: 90px;
         flex-grow: 1;
         padding: 15px;
         min-width: 80px;
       }
-      @media only screen and (max-width: 665px) {
+      @media only screen and (max-width: 600px) {
         height: 70px;
       }
     }
@@ -248,18 +255,18 @@ const S_Wrapper = styled.div`
     & h3 {
       font-size: 20px;
       margin-bottom: 5px;
-      @media only screen and (max-width: 1277px) {
+      @media only screen and (max-width: 1024px) {
         font-size: 17px;
         font-weight: 400;
       }
-      @media only screen and (max-width: 1095px) {
+      @media only screen and (max-width: 1024px) {
         font-size: 16px;
       }
-      @media only screen and (max-width: 665px) {
+      @media only screen and (max-width: 600px) {
         font-size: 14px;
       }
       > span {
-        @media only screen and (max-width: 1095px) {
+        @media only screen and (max-width: 1024px) {
           display: none;
         }
       }
@@ -268,31 +275,31 @@ const S_Wrapper = styled.div`
   & p {
     font-size: 16px;
     color: var(--color-white-80);
-    @media only screen and (max-width: 1277px) {
+    @media only screen and (max-width: 1024px) {
       font-size: 14px;
     }
-    @media only screen and (max-width: 1095px) {
+    @media only screen and (max-width: 1024px) {
       display: none;
     }
   }
   & svg {
     font-size: 35px;
     margin-bottom: 15px;
-    @media only screen and (max-width: 1277px) {
+    @media only screen and (max-width: 1024px) {
       font-size: 30px;
     }
-    @media only screen and (max-width: 1095px) {
+    @media only screen and (max-width: 1024px) {
       font-size: 25px;
       margin-bottom: 5px;
     }
-    @media only screen and (max-width: 665px) {
+    @media only screen and (max-width: 600px) {
       font-size: 20px;
     }
   }
   & svg.arrow {
     font-size: 28px;
     color: var(--color-white-80);
-    @media only screen and (max-width: 1095px) {
+    @media only screen and (max-width: 1024px) {
       display: none;
     }
   }

--- a/client/src/components/banner/MainBanner.tsx
+++ b/client/src/components/banner/MainBanner.tsx
@@ -75,6 +75,10 @@ const S_Wrapper = styled.div`
     justify-content: space-between;
     height: 570px;
   }
+  @media only screen and (max-width: 480px) {
+    padding-top: 50px;
+    height: 450px;
+  }
   & img {
     position: absolute;
     top: 0;

--- a/client/src/components/header/Dropdown.tsx
+++ b/client/src/components/header/Dropdown.tsx
@@ -31,26 +31,26 @@ function Dropdown({
         <img src={avatarUri} alt="user image" />
         <h1>{nickname}</h1>
       </div>
-      <div>
-        <div onClick={() => navigate('/member')}>
+      <ul>
+        <li onClick={() => navigate('/member')}>
           <BsFillPersonFill />
           회원정보
-        </div>
-        <div onClick={() => navigate('/member?content=bookmarks')}>
+        </li>
+        <li onClick={() => navigate('/member?content=bookmarks')}>
           <AiFillHeart />찜 목록
-        </div>
-        <div onClick={logout}>
+        </li>
+        <li onClick={logout}>
           <FiLogOut />
           로그아웃
-        </div>
-      </div>
+        </li>
+      </ul>
     </S_Wrapper>
   );
 }
 
 export default Dropdown;
 
-const S_Wrapper = styled.div`
+const S_Wrapper = styled.nav`
   display: flex;
   flex-direction: column;
   z-index: 9999;
@@ -64,27 +64,36 @@ const S_Wrapper = styled.div`
   box-shadow: 4px 4px 10px 0px rgba(0, 0, 0, 0.4);
   top: 50px;
   right: 10px;
+  @media only screen and (max-width: 480px) {
+    width: 170px;
+    height: 190px;
+  }
   > div:first-child {
     display: flex;
     align-items: center;
     padding: 15px 20px;
     border-bottom: 1px solid var(--color-dropdown-stroke);
   }
-  > div:nth-child(2) {
+  > ul {
     display: flex;
     padding: 5px 0;
     flex-direction: column;
     justify-content: space-around;
     flex-grow: 1;
     color: var(--color-white-80);
-    > div {
+
+    > li {
       padding: 0 20px;
       display: flex;
+      align-items: center;
       cursor: pointer;
+      @media only screen and (max-width: 480px) {
+        font-size: 14px;
+      }
     }
-    > div:hover {
+    > li:hover {
       color: white;
-      transition: color 0.5s ease;
+      transition: color 0.3s ease;
     }
   }
   & img {

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -42,7 +42,7 @@ function Header() {
               <FiSearch />
             </S_Logo>
           )}
-          <MemberMenu />
+          <MemberMenu position={position} />
         </div>
       </S_Wrapper>
     </S_Header>
@@ -52,31 +52,28 @@ function Header() {
 export default Header;
 
 const S_Header = styled.header<{ $visible: boolean }>`
-  transform: ${(props) =>
-    props.$visible ? undefined : 'translate(0, -120px)'};
-  visibility: ${(props) => (props.$visible ? undefined : 'hidden')};
+  transform: ${(props) => (props.$visible ? undefined : 'translate(0, -80px)')};
   display: flex;
   justify-content: center;
   width: 100%;
   top: 0;
   position: sticky;
-  background: linear-gradient(
-    180deg,
-    rgba(20, 24, 31, 0.49) 0%,
-    rgba(20, 24, 31, 0) 100%
-  );
   z-index: 1000;
   transition: transform 0.5s ease;
 `;
 const S_Wrapper = styled.div`
-  margin-top: 15px;
   position: absolute;
   max-width: 1500px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 60px;
+  padding: 15px 60px 0 60px;
   width: 100%;
+  background: linear-gradient(
+    180deg,
+    rgba(20, 24, 31, 0.49) 0%,
+    rgba(20, 24, 31, 0) 100%
+  );
   > div {
     display: flex;
     flex-direction: row;
@@ -92,7 +89,7 @@ const S_Wrapper = styled.div`
   }
 
   @media only screen and (max-width: 770px) {
-    padding: 0 20px;
+    padding: 15px 20px 0 20px;
   }
 `;
 const S_Logo = styled.button`

--- a/client/src/components/header/LoginSignup.tsx
+++ b/client/src/components/header/LoginSignup.tsx
@@ -1,12 +1,23 @@
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { SCROLL_Y_SECTION_1 } from '../../constant/constantValue';
 
-function LoginSignup() {
+function LoginSignup({ position }: { position: number }) {
   const navigate = useNavigate();
   return (
     <S_Wrapper>
-      <S_Button onClick={() => navigate('/login')}>login</S_Button>
-      <S_Button onClick={() => navigate('/signup')}>signup</S_Button>
+      <S_Button
+        className={position >= SCROLL_Y_SECTION_1 ? 'solid' : undefined}
+        onClick={() => navigate('/login')}
+      >
+        login
+      </S_Button>
+      <S_Button
+        className={position >= SCROLL_Y_SECTION_1 ? 'solid' : undefined}
+        onClick={() => navigate('/signup')}
+      >
+        signup
+      </S_Button>
     </S_Wrapper>
   );
 }
@@ -33,6 +44,9 @@ const S_Button = styled.button`
   background-color: #d9d9d933;
   backdrop-filter: blur(3px);
   transition: all 0.3s ease;
+  &.solid {
+    background-color: var(--color-bg-100);
+  }
   &:hover {
     background-color: var(--color-white-60);
     border: 1px solid white;

--- a/client/src/components/header/MemberMenu.tsx
+++ b/client/src/components/header/MemberMenu.tsx
@@ -3,9 +3,13 @@ import useIsLoggedIn from '../../hooks/useIsLoggedIn';
 import UserProfile from './UserProfile';
 import LoginSignup from './LoginSignup';
 
-function MemberMenu() {
+function MemberMenu({ position }: { position: number }) {
   const isLoggedIn = useIsLoggedIn();
-  return <S_Nav>{isLoggedIn ? <UserProfile /> : <LoginSignup />}</S_Nav>;
+  return (
+    <S_Nav>
+      {isLoggedIn ? <UserProfile /> : <LoginSignup position={position} />}
+    </S_Nav>
+  );
 }
 
 export default MemberMenu;

--- a/client/src/components/header/SearchBar.tsx
+++ b/client/src/components/header/SearchBar.tsx
@@ -56,64 +56,73 @@ function SearchBar() {
   };
 
   return (
-    <S_Wrapper isMobile={isMobile}>
-      <div>
-        <img
-          src={logo}
-          onClick={() => {
-            reset();
-            navigate('/');
-          }}
-        />
-        <FaXmark onClick={reset} />
-      </div>
-      <div>
-        <label>
-          <S_Input
-            type="text"
-            value={userInput}
-            onChange={handleChange}
-            onKeyUp={handleKeyUp}
-            placeholder="제목, 인물명으로 검색해보세요."
-            autoFocus
+    <S_Modal>
+      {' '}
+      <S_Wrapper isMobile={isMobile}>
+        <div>
+          <img
+            src={logo}
+            onClick={() => {
+              reset();
+              navigate('/');
+            }}
           />
-        </label>
-        <FiSearch onClick={handleClick} />
-      </div>
-      {data && !!data.length && (
-        <ul className="auto-complete">
-          {data.map((result, i) => (
-            <li
-              key={i}
-              onClick={() => {
-                search(result);
-              }}
-              className={currentOptionIdx === i ? 'currentOption' : ''}
-            >
-              {result}
-            </li>
-          ))}
-        </ul>
-      )}
-    </S_Wrapper>
+          <FaXmark onClick={reset} />
+        </div>
+        <div>
+          <label>
+            <S_Input
+              type="text"
+              value={userInput}
+              onChange={handleChange}
+              onKeyUp={handleKeyUp}
+              placeholder="제목, 인물명으로 검색해보세요."
+              autoFocus
+            />
+          </label>
+          <FiSearch onClick={handleClick} />
+        </div>
+        {data && !!data.length && (
+          <ul className="auto-complete">
+            {data.map((result, i) => (
+              <li
+                key={i}
+                onClick={() => {
+                  search(result);
+                }}
+                className={currentOptionIdx === i ? 'currentOption' : ''}
+              >
+                {result}
+              </li>
+            ))}
+          </ul>
+        )}
+      </S_Wrapper>
+    </S_Modal>
   );
 }
 
 export default SearchBar;
 
-const S_Wrapper = styled.div<{ isMobile: boolean }>`
-  max-width: 1500px;
-  height: ${({ isMobile }) => (isMobile ? '100vh' : '300px')};
+const S_Modal = styled.div`
   width: 100%;
+  display: flex;
+  justify-content: center;
   position: absolute;
   top: 0;
+  transform: translate(-50%, 0);
+  background-color: var(--color-bg-100);
   border-bottom: 2px solid var(--color-dropdown-stroke);
+`;
+
+const S_Wrapper = styled.div<{ isMobile: boolean }>`
+  max-width: 1500px;
+  width: 100%;
+  height: ${({ isMobile }) => (isMobile ? '100vh' : '300px')};
   display: flex;
   flex-direction: column;
   align-items: center;
-  transform: translate(-50%, 0);
   padding: ${({ isMobile }) => (isMobile ? '20px 30px' : '20px 50px;')};
-  background-color: var(--color-bg-100);
   > div:first-child {
     width: 100%;
     display: flex;

--- a/client/src/components/header/SearchBar.tsx
+++ b/client/src/components/header/SearchBar.tsx
@@ -68,14 +68,16 @@ function SearchBar() {
         <FaXmark onClick={reset} />
       </div>
       <div>
-        <S_Input
-          type="text"
-          value={userInput}
-          onChange={handleChange}
-          onKeyUp={handleKeyUp}
-          placeholder="제목, 인물명으로 검색해보세요."
-          autoFocus
-        />
+        <label>
+          <S_Input
+            type="text"
+            value={userInput}
+            onChange={handleChange}
+            onKeyUp={handleKeyUp}
+            placeholder="제목, 인물명으로 검색해보세요."
+            autoFocus
+          />
+        </label>
         <FiSearch onClick={handleClick} />
       </div>
       {data && !!data.length && (
@@ -100,6 +102,7 @@ function SearchBar() {
 export default SearchBar;
 
 const S_Wrapper = styled.div<{ isMobile: boolean }>`
+  max-width: 1500px;
   height: ${({ isMobile }) => (isMobile ? '100vh' : '300px')};
   width: 100%;
   position: absolute;
@@ -122,7 +125,7 @@ const S_Wrapper = styled.div<{ isMobile: boolean }>`
     > svg {
       position: absolute;
       cursor: pointer;
-      right: 20px;
+      right: 10px;
       top: 27px;
     }
   }
@@ -131,7 +134,6 @@ const S_Wrapper = styled.div<{ isMobile: boolean }>`
     background-color: var(--color-bg-100);
     margin-top: -1px;
     padding-top: 0.5rem;
-    border-radius: 0 0 1rem 1rem;
     z-index: 3;
     > li {
       width: 100%;
@@ -157,16 +159,20 @@ const S_Wrapper = styled.div<{ isMobile: boolean }>`
     color: white;
     cursor: pointer;
   }
+  & label {
+    border-bottom: 2px solid white;
+    padding: 5px 0;
+  }
 `;
 
 const S_Input = styled.input`
+  width: 100%;
   margin-top: 20px;
   border: none;
-  border-bottom: 2px solid white;
-  width: 100%;
+  /* border-bottom: 2px solid white; */
   height: 42px;
-  padding: 2px 10px;
+  padding: 0 10px;
   font-size: 17px;
-  background: rgba(217, 217, 217, 0);
+  background: transparent;
   color: var(--color-white-60);
 `;

--- a/client/src/components/ui/MobileGNB.tsx
+++ b/client/src/components/ui/MobileGNB.tsx
@@ -82,7 +82,7 @@ const S_Wrapper = styled.ul`
     justify-content: end;
   }
   & h1 {
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 400;
   }
   & svg {

--- a/client/src/constant/constantValue.ts
+++ b/client/src/constant/constantValue.ts
@@ -2,6 +2,7 @@ export const COMMENTS_PER_PAGE = 5;
 export const PAGES_PER_SECTION = 5;
 export const ADMIN_MEMBERID = 2;
 export const AUTOCOMPLETE_RESULT_SIZE = 5;
+export const SCROLL_Y_SECTION_1 = 400;
 
 export const genres = [
   '액션',


### PR DESCRIPTION
### PR에 관한 간략한 설명
헤더의 가독성을 향상시키고 모바일뷰에 맞춰서 상단 패딩을 줄였습니다.
메인 배너의 미디어쿼리 브레이크포인트를 정리했습니다.

### 기능 구현 및 수정 세부 사항
 - [x] 헤더에 배경 그래디언트를 넣어서 가독성 향상
 - [x] 로그인, 회원가입 버튼 스크롤시 불투명하게 함
 - [x] 모바일뷰에서 메인 배너의 상단 여백을 줄임
 - [x] 모바일 GNB 폰트 크기 줄임
 - [x] 서치바 모달이 100vw로 확장되게 하되 검색창 부분은 1500px을 넘지 않게 함
 - [x] 메인 배너의 미디어쿼리 브레이크포인트를 정리
