### PR TITLE
fix: 의문의 좌우씹힘 제거

### DIFF
--- a/client/src/components/ui/ListBtns.tsx
+++ b/client/src/components/ui/ListBtns.tsx
@@ -53,8 +53,11 @@ const S_Wrapper = styled.div`
     margin-right: 15px;
   }
 
-  @media only screen and (max-width: 600px) {
+  @media only screen and (max-width: 770px) {
     padding-left: 20px;
+  }
+
+  @media only screen and (max-width: 600px) {
     .bar {
       font-size: 16px;
     }

--- a/client/src/components/ui/modal/genre/MobileGenreModal.tsx
+++ b/client/src/components/ui/modal/genre/MobileGenreModal.tsx
@@ -49,7 +49,7 @@ function MobileGenreModal({
           direction={'vertical'}
           slidesPerView={15}
           centeredSlides={true}
-          initialSlide={centeredSlideIndex}
+          initialSlide={centeredSlideIndex + 1}
           className="mySwiper"
         >
           <S_SwiperSlide className="arrow">

--- a/client/src/styles/style.ts
+++ b/client/src/styles/style.ts
@@ -24,8 +24,7 @@ export const S_Root = styled.div`
 
 /* ----- Wrapper Root-Main ----- */
 export const S_Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
+  margin: 0 auto;
   flex-grow: 1;
   overflow-x: hidden;
 `;
@@ -116,7 +115,7 @@ export const S_Modal = styled.div`
     font-size: 22px;
     font-weight: 400;
     color: var(--color-white-80);
-    
+
     @media only screen and (max-width: 600px) {
       font-size: 16px;
     }


### PR DESCRIPTION
```export const S_Wrapper = styled.div`
  display: flex;
  justify-content: center;```

이 두 속성이 html크기보다 메인컨텐츠가 더넓은 크기를 갖게만듬 (Y스크롤바 크기가 포함됬거나 justify-content로 좌우에 뭔가생긴듯)

이전에 헤더와 바디의 너비가 다른문제를 해결.

버셀 프리뷰로 체크하고 머지부탁드립니다