### PR TITLE
:bug: Fix: 추천해조잉 모바일 버전에서 버튼을 눌렀다 뗐을 때 밝기 효과가 남아있는 현상 해결

### DIFF
--- a/client/src/components/ui/questions/FirstQuestion.tsx
+++ b/client/src/components/ui/questions/FirstQuestion.tsx
@@ -187,8 +187,10 @@ const S_OttIcon = styled.img`
     opacity: 1;
   }
 
-  &:hover {
-    filter: brightness(100%);
+  @media (hover: hover) {
+    &:hover {
+      filter: brightness(100%);
+    }
   }
 
   @media only screen and (max-width: 770px) {

--- a/client/src/components/ui/questions/SecondQuestion.tsx
+++ b/client/src/components/ui/questions/SecondQuestion.tsx
@@ -158,8 +158,10 @@ const S_CategoryIcon = styled.img`
     opacity: 1;
   }
 
-  &:hover {
-    filter: brightness(100%);
+  @media (hover: hover) {
+    &:hover {
+      filter: brightness(100%);
+    }
   }
 
   @media only screen and (max-width: 770px) {

--- a/client/src/components/ui/questions/ThirdQuestion.tsx
+++ b/client/src/components/ui/questions/ThirdQuestion.tsx
@@ -185,6 +185,13 @@ const S_CheckBox = styled.input.attrs({ type: 'checkbox' })`
     filter: none;
     opacity: 1;
   }
+  
+  @media (hover: hover) {
+    &:hover {
+      background-image: url(${beehappy.text});
+      filter: brightness(100%);
+    }
+  }
 
   @media only screen and (max-width: 480px) {
     margin-right: 0px;


### PR DESCRIPTION
## 수정 사항
- [x] 추천해조잉 모바일 버전에서 버튼을 눌렀다 뗐을 때 밝기 효과가 남아있는 현상 해결
  - PC와 같은 포인터를 사용하는 환경에서만 :hover 스타일이 적용
    ```js
      &:hover {
        filter: brightness(100%);
      @media (hover: hover) {
        &:hover {
          filter: brightness(100%);
        }
      }
    ```